### PR TITLE
fix(layout): add mobile navigation menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,15 @@ npm run lint         # ESLint
 npm run format       # Prettier write
 npm run format:check # Prettier check
 
-npm run test:unit    # Vitest (unit tests only)
+npm run test:unit    # Vitest unit tests
 npm run test:e2e     # Playwright e2e smoke tests
-npm run test:visual  # Playwright visual regression
-npm run test         # All three above
+npm run test         # Unit tests + Playwright e2e smoke tests
 
 # Run a single unit test file
 npx vitest run src/features/share-planner/share-planner.test.ts
+
+# Run the mobile e2e project
+npx playwright test --project mobile-chromium
 ```
 
 ## Architecture

--- a/src/components/astro/LanguageSwitch.astro
+++ b/src/components/astro/LanguageSwitch.astro
@@ -19,7 +19,7 @@ const alternatePath = switchLocalePath(pathname, alternateLocale);
 <a
   href={alternatePath}
   data-preserve-hash-link
-  class="inline-flex items-center gap-1.5 border px-3 py-1.5 text-[10px] font-bold tracking-[0.24em] uppercase transition"
+  class="inline-flex items-center gap-1.5 border px-2.5 py-1 text-[9px] font-bold tracking-[0.22em] uppercase transition sm:px-3 sm:py-1.5 sm:text-[10px] sm:tracking-[0.24em]"
   style="border-color: rgba(30,111,160,0.25); background-color: rgba(30,111,160,0.07); color: var(--color-accent);"
   onmouseover="this.style.backgroundColor='rgba(30,111,160,0.14)'; this.style.borderColor='rgba(30,111,160,0.5)';"
   onmouseout="this.style.backgroundColor='rgba(30,111,160,0.07)'; this.style.borderColor='rgba(30,111,160,0.25)';"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,6 +20,17 @@ const {
 } = Astro.props;
 const dictionary = getDictionary(locale as Locale);
 const seo = buildSeo({ locale, title, description, pathname, noindex });
+const navLinks = [
+  {
+    href: `/${locale}/races`,
+    label: dictionary.raceDiscovery,
+  },
+  {
+    href: `/${locale}/about`,
+    label: dictionary.about,
+  },
+];
+const mobileNavId = "site-mobile-nav";
 ---
 
 <!doctype html>
@@ -53,42 +64,89 @@ const seo = buildSeo({ locale, title, description, pathname, noindex });
       style="background-color: var(--color-surface); border-bottom: 1px solid var(--color-line);"
     >
       <div
-        class="mx-auto flex max-w-6xl items-center justify-between gap-6 px-5 py-3 sm:px-8"
+        class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:gap-6 sm:px-8"
       >
-        <a href={`/${locale}`} class="flex items-center gap-3">
-          <img src="/logo.png" alt="Dondeteveo" class="h-9 w-auto" />
-          <div>
+        <a
+          href={`/${locale}`}
+          class="flex min-w-0 items-center gap-2.5 sm:gap-3"
+        >
+          <img src="/logo.png" alt="Dondeteveo" class="h-8 w-auto sm:h-9" />
+          <div class="min-w-0">
             <div
-              class="font-display text-2xl leading-none font-bold uppercase"
+              class="font-display text-xl leading-none font-bold uppercase sm:text-2xl"
               style="color: var(--color-accent);"
             >
               DONDETEVEO
             </div>
             <div
-              class="mt-0.5 font-mono text-[9px] tracking-[0.28em] uppercase"
+              class="mt-0.5 hidden font-mono text-[9px] tracking-[0.28em] uppercase sm:block"
               style="color: var(--color-muted);"
             >
               {dictionary.siteTagline}
             </div>
           </div>
         </a>
-        <nav class="flex items-center gap-5">
-          <a
-            href={`/${locale}/races`}
-            class="nav-link hidden font-mono text-xs tracking-[0.18em] uppercase transition-colors sm:inline"
-            style="color: var(--color-muted);"
+        <div class="flex items-center gap-2 sm:gap-5">
+          <nav
+            class="hidden items-center gap-5 sm:flex"
+            aria-label={dictionary.primaryNavigation}
           >
-            {dictionary.raceDiscovery}
-          </a>
-          <a
-            href={`/${locale}/about`}
-            class="nav-link hidden font-mono text-xs tracking-[0.18em] uppercase transition-colors sm:inline"
-            style="color: var(--color-muted);"
-          >
-            {dictionary.about}
-          </a>
+            {
+              navLinks.map((link) => (
+                <a
+                  href={link.href}
+                  class="nav-link font-mono text-xs tracking-[0.18em] uppercase transition-colors"
+                  style="color: var(--color-muted);"
+                >
+                  {link.label}
+                </a>
+              ))
+            }
+          </nav>
           <LanguageSwitch currentLocale={locale} pathname={pathname} />
-        </nav>
+          <details class="mobile-nav relative sm:hidden" data-mobile-nav>
+            <summary
+              class="mobile-nav-toggle flex list-none items-center justify-center"
+              aria-controls={mobileNavId}
+              aria-expanded="false"
+              aria-label={dictionary.openMenu}
+              data-mobile-nav-toggle
+              data-open-label={dictionary.openMenu}
+              data-close-label={dictionary.closeMenu}
+            >
+              <span class="sr-only" data-mobile-nav-toggle-text
+                >{dictionary.openMenu}</span
+              >
+              <span class="mobile-nav-toggle-lines" aria-hidden="true">
+                <span class="mobile-nav-toggle-line"></span>
+                <span class="mobile-nav-toggle-line"></span>
+                <span class="mobile-nav-toggle-line"></span>
+              </span>
+            </summary>
+            <div
+              id={mobileNavId}
+              class="mobile-nav-panel"
+              data-mobile-nav-panel
+            >
+              <nav
+                class="flex flex-col gap-2"
+                aria-label={dictionary.primaryNavigation}
+              >
+                {
+                  navLinks.map((link) => (
+                    <a
+                      href={link.href}
+                      class="mobile-nav-link"
+                      data-mobile-nav-link
+                    >
+                      {link.label}
+                    </a>
+                  ))
+                }
+              </nav>
+            </div>
+          </details>
+        </div>
       </div>
     </header>
 
@@ -107,5 +165,65 @@ const seo = buildSeo({ locale, title, description, pathname, noindex });
         <slot />
       </div>
     </main>
+    <script is:inline>
+      const mobileNav = document.querySelector("[data-mobile-nav]");
+      const mobileNavToggle = document.querySelector(
+        "[data-mobile-nav-toggle]",
+      );
+
+      if (
+        mobileNav instanceof HTMLDetailsElement &&
+        mobileNavToggle instanceof HTMLElement
+      ) {
+        const mobileNavToggleText = mobileNavToggle.querySelector(
+          "[data-mobile-nav-toggle-text]",
+        );
+
+        const syncMobileNavState = () => {
+          const isOpen = mobileNav.open;
+          const label = isOpen
+            ? mobileNavToggle.dataset.closeLabel
+            : mobileNavToggle.dataset.openLabel;
+
+          mobileNavToggle.setAttribute("aria-expanded", String(isOpen));
+
+          if (label) {
+            mobileNavToggle.setAttribute("aria-label", label);
+
+            if (mobileNavToggleText instanceof HTMLElement) {
+              mobileNavToggleText.textContent = label;
+            }
+          }
+        };
+
+        const closeMobileNav = () => {
+          mobileNav.open = false;
+          syncMobileNavState();
+        };
+
+        mobileNav.addEventListener("toggle", syncMobileNavState);
+
+        mobileNav
+          .querySelectorAll("[data-mobile-nav-link]")
+          .forEach((link) => link.addEventListener("click", closeMobileNav));
+
+        document.addEventListener("keydown", (event) => {
+          if (event.key === "Escape" && mobileNav.open) {
+            closeMobileNav();
+            mobileNavToggle.focus();
+          }
+        });
+
+        window
+          .matchMedia("(min-width: 640px)")
+          .addEventListener("change", (event) => {
+            if (event.matches && mobileNav.open) {
+              closeMobileNav();
+            }
+          });
+
+        syncMobileNavState();
+      }
+    </script>
   </body>
 </html>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,6 +2,7 @@ import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./config";
 
 type Dictionary = {
   about: string;
+  closeMenu: string;
   allFilter: string;
   allTimesRaceLocal: string;
   justOpenTitle: string;
@@ -28,10 +29,12 @@ type Dictionary = {
   noMatch: string;
   officialWebsite: string;
   optionalNickname: string;
+  openMenu: string;
   pace: string;
   pacePerKm: string;
   pastEdition: string;
   plannerMode: string;
+  primaryNavigation: string;
   predictedTimes: string;
   privacy: string;
   privacyBody: string;
@@ -67,6 +70,7 @@ type Dictionary = {
 const DICTIONARIES: Record<Locale, Dictionary> = {
   en: {
     about: "About",
+    closeMenu: "Close menu",
     allFilter: "All",
     allTimesRaceLocal: "All times are in the race\u2019s local timezone.",
     justOpenTitle: "Just open the link",
@@ -98,10 +102,12 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     noMatch: "No races match your filters yet.",
     officialWebsite: "Official website",
     optionalNickname: "Optional nickname",
+    openMenu: "Open menu",
     pace: "Pace",
     pacePerKm: "Pace per km",
     pastEdition: "Past edition",
     plannerMode: "Mode",
+    primaryNavigation: "Primary navigation",
     predictedTimes: "Predicted times",
     privacy: "Privacy",
     privacyBody:
@@ -140,6 +146,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
   },
   es: {
     about: "Acerca de",
+    closeMenu: "Cerrar menú",
     allFilter: "Todas",
     allTimesRaceLocal:
       "Todos los horarios están en la zona horaria de la carrera.",
@@ -173,10 +180,12 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     noMatch: "Todavía no hay carreras que coincidan con los filtros.",
     officialWebsite: "Web oficial",
     optionalNickname: "Apodo (opcional)",
+    openMenu: "Abrir menú",
     pace: "Ritmo",
     pacePerKm: "Ritmo por km",
     pastEdition: "Edición pasada",
     plannerMode: "Modo",
+    primaryNavigation: "Navegación principal",
     predictedTimes: "Horarios estimados",
     privacy: "Privacidad",
     privacyBody:

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -90,6 +90,112 @@ button {
   color: var(--color-accent);
 }
 
+.mobile-nav-toggle {
+  width: 2.625rem;
+  height: 2.625rem;
+  border: 1px solid var(--color-line-solid);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-accent);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+}
+
+.mobile-nav-toggle::marker,
+.mobile-nav-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.mobile-nav-toggle:hover {
+  border-color: rgba(30, 111, 160, 0.4);
+  background-color: rgba(30, 111, 160, 0.08);
+}
+
+.mobile-nav-toggle:focus-visible {
+  outline: 2px solid var(--color-coral);
+  outline-offset: 2px;
+}
+
+.mobile-nav-toggle-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mobile-nav-toggle-line {
+  width: 1rem;
+  height: 2px;
+  background-color: currentColor;
+  transition:
+    transform var(--duration-fast) var(--ease-out),
+    opacity var(--duration-fast) var(--ease-out);
+}
+
+.mobile-nav[open] .mobile-nav-toggle {
+  border-color: rgba(30, 111, 160, 0.42);
+  background-color: rgba(30, 111, 160, 0.12);
+}
+
+.mobile-nav[open] .mobile-nav-toggle-line:nth-child(1) {
+  transform: translateY(5.8px) rotate(45deg);
+}
+
+.mobile-nav[open] .mobile-nav-toggle-line:nth-child(2) {
+  opacity: 0;
+}
+
+.mobile-nav[open] .mobile-nav-toggle-line:nth-child(3) {
+  transform: translateY(-5.8px) rotate(-45deg);
+}
+
+.mobile-nav-panel {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  z-index: 20;
+  width: min(18rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid var(--color-line-solid);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.98),
+    rgba(230, 239, 247, 0.98)
+  );
+  box-shadow: var(--shadow-md);
+  animation: boardFlip 220ms var(--ease-out) both;
+}
+
+.mobile-nav-link {
+  display: block;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--color-line);
+  background-color: rgba(30, 111, 160, 0.04);
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+}
+
+.mobile-nav-link:hover {
+  border-color: rgba(30, 111, 160, 0.35);
+  background-color: rgba(30, 111, 160, 0.1);
+  color: var(--color-accent);
+}
+
+.mobile-nav-link:focus-visible {
+  outline: 2px solid var(--color-coral);
+  outline-offset: 2px;
+}
+
 .fade-in {
   animation: raceReveal 450ms var(--ease-out) both;
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,5 +1,15 @@
 import { expect, test } from "@playwright/test";
 
+const expectNoHorizontalOverflow = async (
+  page: import("@playwright/test").Page,
+) => {
+  const hasOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth,
+  );
+
+  expect(hasOverflow).toBe(false);
+};
+
 test("root redirects to a localized homepage", async ({ page }) => {
   await page.goto("/");
   await page.waitForURL(/\/(en|es)$/);
@@ -30,4 +40,41 @@ test("share page stays noindex", async ({ page }) => {
     .locator('meta[name="robots"]')
     .getAttribute("content");
   expect(robotsContent).toBe("noindex,follow");
+});
+
+test("mobile navigation opens and links work", async ({ page }, testInfo) => {
+  test.skip(
+    !testInfo.project.name.includes("mobile"),
+    "Mobile-only navigation test",
+  );
+
+  await page.goto("/en");
+  await expectNoHorizontalOverflow(page);
+
+  const menuToggle = page.locator("[data-mobile-nav-toggle]");
+
+  await expect(menuToggle).toHaveAttribute("aria-expanded", "false");
+  await menuToggle.click();
+  await expect(menuToggle).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("[data-mobile-nav-panel]")).toBeVisible();
+  await expect(page.getByRole("link", { name: /About/i })).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  await page.keyboard.press("Escape");
+  await expect(menuToggle).toHaveAttribute("aria-expanded", "false");
+
+  await menuToggle.click();
+  await expect(menuToggle).toHaveAttribute("aria-expanded", "true");
+
+  await page.getByRole("link", { name: /About/i }).click();
+  await expect(page).toHaveURL(/\/en\/about$/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: /About/i }),
+  ).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  await page.locator("[data-mobile-nav-toggle]").click();
+  await page.getByRole("link", { name: /Race discovery/i }).click();
+  await expect(page).toHaveURL(/\/en\/races$/);
+  await expectNoHorizontalOverflow(page);
 });


### PR DESCRIPTION
## Summary
- restore access to the primary navigation on small screens with a hamburger menu
- keep the mobile header compact while preserving locale switching and accessible nav labels
- update the repo command reference so documented commands match the scripts that exist today

## Changes
- add a mobile-only hamburger menu in `src/layouts/BaseLayout.astro` with `aria-expanded`, Escape handling, resize cleanup, and tap targets for all primary links
- tighten the mobile header sizing in `src/layouts/BaseLayout.astro`, `src/components/astro/LanguageSwitch.astro`, and `src/styles/global.css` so the controls fit narrow viewports without overflow
- add localized menu strings in `src/lib/i18n.ts` and Playwright mobile coverage in `tests/e2e/app.spec.ts` for menu open/close behavior, navigation, and overflow checks
- correct the command list in `CLAUDE.md` to match the current npm scripts and Playwright mobile invocation

## Test Plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check`
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] E2E smoke tests pass (`npm run test:e2e`)
- [x] Manual testing completed

## Docs Impact
- docs updated (`CLAUDE.md` command list corrected)

Closes #32