### PR TITLE
feat(share): context-aware h1 with nickname (#21)

### DIFF
--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -47,6 +47,25 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
   };
 
   const shareState = useMemo(() => parseShareState(fragment), [fragment]);
+
+  useEffect(() => {
+    const staticH1 = document.getElementById("share-h1-static");
+    const anchor = document.getElementById("share-h1-name-anchor");
+    if (!staticH1 || !anchor || !shareState?.name) return;
+
+    const nameSpan = document.createElement("span");
+    nameSpan.textContent = `${shareState.name} `;
+    nameSpan.style.color = "var(--color-accent)";
+    nameSpan.style.opacity = "0";
+    nameSpan.style.transition = "opacity 600ms ease-out";
+
+    anchor.after(nameSpan);
+
+    requestAnimationFrame(() => {
+      nameSpan.style.opacity = "1";
+    });
+  }, [shareState?.name]);
+
   const points = getPointSummaries(edition.points);
   const paceMinutesPerKm = shareState
     ? resolvePaceMinutesPerKm(shareState, edition.meta.distanceKm)

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -51,6 +51,7 @@ type Dictionary = {
   share: string;
   shareIntro: string;
   shareNeedsJavaScript: string;
+  sharePageForThe: string;
   sharePageTitle: string;
   shareReadyBody: string;
   shareReadyTitle: string;
@@ -131,7 +132,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
       "Enter your target pace or finish time and generate a spectator-ready link.",
     shareNeedsJavaScript:
       "This share page needs JavaScript enabled to read the shared plan from the URL.",
-    sharePageTitle: "Share page",
+    sharePageForThe: "for the",
+    sharePageTitle: "Where to cheer",
     shareReadyBody:
       "Set a target pace or finish time, get a link your supporters can actually use.",
     shareReadyTitle: "Share-ready",
@@ -212,7 +214,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
       "Escribe tu ritmo objetivo o tiempo de llegada y crea un enlace listo para tus animadores.",
     shareNeedsJavaScript:
       "Esta página necesita JavaScript para leer el plan compartido desde la URL.",
-    sharePageTitle: "Página para compartir",
+    sharePageForThe: "en el",
+    sharePageTitle: "Dónde animar",
     shareReadyBody:
       "Pon tu ritmo o tiempo de llegada y obtén un enlace que tus animadores pueden usar de verdad.",
     shareReadyTitle: "Listo para compartir",

--- a/src/pages/[locale]/share/[race]/[year].astro
+++ b/src/pages/[locale]/share/[race]/[year].astro
@@ -40,10 +40,15 @@ const pathname = `/${locale}/share/${edition.raceSlug}/${edition.year}`;
 >
   <div class="max-w-3xl">
     <h1
+      id="share-h1-static"
       class="font-display leading-none font-bold uppercase"
       style={`font-size: clamp(2.5rem, 10vw, 5rem); color: var(--color-text);`}
     >
-      {dictionary.sharePageTitle}
+      {dictionary.sharePageTitle}{" "}<span
+        id="share-h1-name-anchor"
+        style="display:contents;"></span>{dictionary.sharePageForThe}{" "}{
+        edition.meta.name
+      }
     </h1>
     <p
       class="mt-4 font-mono text-sm leading-7"


### PR DESCRIPTION
## Summary
- Server-renders **"Where to cheer for the [Race]"** as the share page h1 (new i18n keys: `sharePageTitle` → "Where to cheer"/"Dónde animar", `sharePageForThe` → "for the"/"en el")
- On hydration, if a nickname exists in the URL fragment, it is **inserted** into the h1 ("Where to cheer **Ana** for the Boston Marathon") with a gentle 600ms fade-in
- Nickname is highlighted in `--color-accent` for visual distinction
- Uses safe DOM APIs (no innerHTML) — name comes from Zod-validated share state

## Test plan
- [ ] Open a share URL **without** a nickname → h1 shows "Where to cheer for the [Race]"
- [ ] Open a share URL **with** a nickname → h1 initially shows generic, then nickname fades in with accent color
- [ ] Verify both EN and ES locales render correctly
- [ ] Verify error state (invalid fragment) still works

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)