### PR TITLE
feat(data): add race contribution guide and contribute page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing Race Data
+
+Thank you for helping grow the Dondeteveo race catalog! This guide explains how to contribute a new race edition via pull request.
+
+## Race Data Structure
+
+Each race edition lives in its own folder:
+
+```
+data/<iso-country>/<race-slug>/<year>/
+  meta.json         # Race metadata
+  route.geojson     # LineString route geometry
+  points.geojson    # Split and cheer-point features
+  source.json       # Data provenance
+```
+
+- `<iso-country>` — lowercase ISO 3166-1 alpha-2 code (e.g. `es`, `us`, `gb`)
+- `<race-slug>` — kebab-case, globally unique across the catalog (e.g. `sevilla-half-marathon`)
+- `<year>` — edition year (e.g. `2026`)
+
+See `data/es/sevilla-half-marathon/2026/` for a complete working example.
+
+## Required Files
+
+### `meta.json`
+
+| Field                | Type                | Required | Notes                                   |
+| -------------------- | ------------------- | -------- | --------------------------------------- |
+| `name`               | string              | yes      | Display name                            |
+| `date`               | string `YYYY-MM-DD` | yes      | Race day in local timezone              |
+| `distanceKm`         | number              | yes      | e.g. `21.0975`                          |
+| `city`               | string              | yes      | Host city display name                  |
+| `startTime`          | string `HH:MM`      | yes      | Gun start in race local timezone        |
+| `timezone`           | string (IANA)       | yes      | e.g. `"Europe/Madrid"`                  |
+| `officialWebsiteUrl` | string (URL)        | yes      | Link to the official race website       |
+| `summary`            | string              | no       | 1–2 sentence description for race pages |
+| `heroNote`           | string              | no       | Spectator-specific note for share pages |
+
+Example:
+
+```json
+{
+  "name": "Zurich Seville Half Marathon",
+  "date": "2026-01-25",
+  "distanceKm": 21.0975,
+  "city": "Seville",
+  "startTime": "09:00",
+  "timezone": "Europe/Madrid",
+  "officialWebsiteUrl": "https://www.zurichmaratonsevilla.es/media-maraton/",
+  "summary": "Fast winter half marathon in the center of Seville.",
+  "heroNote": "A spectator-friendly course with multiple central cheering opportunities."
+}
+```
+
+### `route.geojson`
+
+A standard GeoJSON `FeatureCollection` containing a single `Feature` with a `LineString` geometry representing the race route.
+
+### `points.geojson`
+
+A GeoJSON `FeatureCollection` of `Point` features. Each feature must have these properties:
+
+| Property     | Type                         | Notes                                                            |
+| ------------ | ---------------------------- | ---------------------------------------------------------------- |
+| `id`         | string                       | Unique kebab-case identifier (e.g. `"km-10"`)                    |
+| `label`      | string                       | Display label (e.g. `"10K split"`)                               |
+| `kind`       | `"split"` or `"cheer-point"` | `split` for timing points, `cheer-point` for spectator locations |
+| `distanceKm` | number                       | Distance from start along the route                              |
+
+Include at minimum: `start`, key kilometer splits, and `finish`.
+
+### `source.json`
+
+| Field                | Notes                                 |
+| -------------------- | ------------------------------------- |
+| `officialSourceName` | Human-readable source name            |
+| `officialSourceUrl`  | URL to the official source            |
+| `routeSourceType`    | `"gpx"`, `"kml"`, or `"manual-trace"` |
+| `notes`              | Free-text audit notes                 |
+
+## Tools for Creating Route Data
+
+You don't need specialized software to create race routes. These free online tools let you draw routes on a map and export them in formats we can use:
+
+- **[geojson.io](https://geojson.io)** — Draw routes (LineString) and points directly on a map and export as GeoJSON. This is the most direct option since Dondeteveo uses GeoJSON natively. You can create both `route.geojson` and `points.geojson` here.
+- **[plotaroute.com](https://www.plotaroute.com)** — Trace a route along roads with automatic snap-to-path. Great for accuracy since it follows real streets. Export as GPX, then convert to GeoJSON using geojson.io (import the GPX file there).
+- **[mapstogpx.com](https://mapstogpx.com)** — Convert Google Maps directions into a GPX file. Useful if the race route follows a path you can replicate with Google Maps directions. Convert the resulting GPX to GeoJSON via geojson.io.
+
+**Tip:** Many official race websites publish route maps or GPX/KML files. Check the race's official site first — you may be able to download the route directly and convert it to GeoJSON.
+
+## Step-by-Step PR Instructions
+
+1. **Fork** the repository and clone your fork.
+2. **Create a branch**: `git checkout -b data/<race-slug>-<year>` (e.g. `data/boston-marathon-2026`).
+3. **Create the folder**: `data/<iso-country>/<race-slug>/<year>/`.
+4. **Add the four required files** following the schemas above.
+5. **Run validation**:
+   ```bash
+   npm run build        # Confirms the data loads correctly
+   npm run check        # Type checking
+   npm run lint         # Linting
+   ```
+6. **Commit and push** your branch.
+7. **Open a pull request** against `main` with a brief description of the race.
+
+## QA Checklist
+
+Before submitting, verify:
+
+- [ ] All four required files are present (`meta.json`, `route.geojson`, `points.geojson`, `source.json`)
+- [ ] All required metadata fields are filled in
+- [ ] Race slug is globally unique (not used by another race)
+- [ ] Timezone is present and uses an IANA timezone identifier
+- [ ] Source information is present and accurate
+- [ ] Route and points load correctly (`npm run build` passes)
+- [ ] Points include at least `start` and `finish`
+
+## Can't Submit a PR?
+
+No worries! You can also request a race by [opening a GitHub issue](https://github.com/josescgar/dondeteveo/issues/new) or sending an email to jose.escobar.dev@gmail.com.

--- a/docs/data-race-catalog.md
+++ b/docs/data-race-catalog.md
@@ -65,6 +65,10 @@
 - Record whether route data came from GPX/KML or manual tracing.
 - Record enough notes to audit or update the edition later.
 
+## Community Contributions
+
+Community members can contribute new races via pull request. See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full guide, including data schemas, folder structure, and QA checklist.
+
 ## Curation Workflow
 
 - Add or update one edition at a time.

--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -197,8 +197,33 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             style="border-color: var(--color-line); color: var(--color-muted);"
           >
             {dictionary.noMatch}
+            <a
+              href={`/${locale}/contribute`}
+              class="mt-2 block text-sm transition"
+              style="color: var(--color-accent);"
+            >
+              {dictionary.cantFindRace} →
+            </a>
           </div>
         )}
+      </div>
+
+      <div class="mt-6 text-center">
+        <a
+          href={`/${locale}/contribute`}
+          class="font-mono text-sm transition"
+          style="color: var(--color-muted);"
+          onMouseOver={(e) => {
+            (e.currentTarget as HTMLAnchorElement).style.color =
+              "var(--color-accent)";
+          }}
+          onMouseOut={(e) => {
+            (e.currentTarget as HTMLAnchorElement).style.color =
+              "var(--color-muted)";
+          }}
+        >
+          {dictionary.cantFindRace} →
+        </a>
       </div>
     </div>
   );

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,6 +2,7 @@ import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./config";
 
 type Dictionary = {
   about: string;
+  cantFindRace: string;
   closeMenu: string;
   allFilter: string;
   allTimesRaceLocal: string;
@@ -12,6 +13,19 @@ type Dictionary = {
   city: string;
   contactIntro: string;
   contactLabel: string;
+  contributeEmail: string;
+  contributeGithubIssue: string;
+  contributeIntro: string;
+  contributeRequest: string;
+  contributeRequestBody: string;
+  contributeTitle: string;
+  contributeTools: string;
+  contributeToolsBody: string;
+  contributeToolGeojsonio: string;
+  contributeToolPlotaroute: string;
+  contributeToolMapstogpx: string;
+  contributeViaGithub: string;
+  contributeViaGithubBody: string;
   country: string;
   date: string;
   directRaceSearch: string;
@@ -74,6 +88,7 @@ type Dictionary = {
 const DICTIONARIES: Record<Locale, Dictionary> = {
   en: {
     about: "About",
+    cantFindRace: "Can't find your race?",
     closeMenu: "Close menu",
     allFilter: "All",
     allTimesRaceLocal: "All times are in the race\u2019s local timezone.",
@@ -86,6 +101,25 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     contactIntro:
       "Made by Jerna Digital for simple, spectator-friendly race planning.",
     contactLabel: "Contact",
+    contributeEmail: "Send an email",
+    contributeGithubIssue: "Open a GitHub issue",
+    contributeIntro:
+      "We're building a curated catalog of races. You can help it grow — either by contributing race data directly or by requesting a race you'd like to see.",
+    contributeRequest: "Request a race",
+    contributeRequestBody:
+      "Don't have the data or not comfortable with GitHub? No problem — just let us know which race you'd like to see added.",
+    contributeTitle: "Contribute a race",
+    contributeTools: "Tools for creating route data",
+    contributeToolsBody:
+      "You don't need specialized software to create race routes. These free online tools let you draw routes on a map and export them as GeoJSON or GPX.",
+    contributeToolGeojsonio:
+      "draw routes and points directly on a map, export as GeoJSON",
+    contributeToolPlotaroute:
+      "trace a route along roads with snap-to-path, export as GPX",
+    contributeToolMapstogpx: "convert Google Maps directions into a GPX file",
+    contributeViaGithub: "Contribute via GitHub",
+    contributeViaGithubBody:
+      "If you have route and checkpoint data for a race, you can submit it as a pull request. Check the contribution guide for the full instructions.",
     country: "Country",
     date: "Edition",
     directRaceSearch: "Find your race",
@@ -154,6 +188,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
   },
   es: {
     about: "Acerca de",
+    cantFindRace: "¿No encuentras tu carrera?",
     closeMenu: "Cerrar menú",
     allFilter: "Todas",
     allTimesRaceLocal:
@@ -167,6 +202,26 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     contactIntro:
       "Hecho por Jerna Digital para que animar sea tan fácil como correr.",
     contactLabel: "Contacto",
+    contributeEmail: "Enviar un email",
+    contributeGithubIssue: "Abrir un issue en GitHub",
+    contributeIntro:
+      "Estamos construyendo un catálogo de carreras curado. Puedes ayudar a que crezca — contribuyendo datos de carreras directamente o pidiendo una que te gustaría ver.",
+    contributeRequest: "Solicitar una carrera",
+    contributeRequestBody:
+      "¿No tienes los datos o no te manejas con GitHub? Sin problema — simplemente dinos qué carrera te gustaría que añadiéramos.",
+    contributeTitle: "Contribuir una carrera",
+    contributeTools: "Herramientas para crear datos de ruta",
+    contributeToolsBody:
+      "No necesitas software especializado para crear rutas de carreras. Estas herramientas online gratuitas te permiten dibujar rutas sobre un mapa y exportarlas como GeoJSON o GPX.",
+    contributeToolGeojsonio:
+      "dibuja rutas y puntos directamente sobre un mapa, exporta como GeoJSON",
+    contributeToolPlotaroute:
+      "traza una ruta por carreteras con ajuste automático al camino, exporta como GPX",
+    contributeToolMapstogpx:
+      "convierte indicaciones de Google Maps en un archivo GPX",
+    contributeViaGithub: "Contribuir via GitHub",
+    contributeViaGithubBody:
+      "Si tienes datos de ruta y puntos de control de una carrera, puedes enviarlos como pull request. Consulta la guía de contribución para las instrucciones completas.",
     country: "País",
     date: "Edición",
     directRaceSearch: "Encuentra tu carrera",

--- a/src/pages/[locale]/contribute.astro
+++ b/src/pages/[locale]/contribute.astro
@@ -1,0 +1,164 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+import {
+  GITHUB_REPOSITORY_URL,
+  type Locale,
+  SUPPORTED_LOCALES,
+} from "../../lib/config";
+import { getDictionary } from "../../lib/i18n";
+
+export const getStaticPaths = () =>
+  SUPPORTED_LOCALES.map((locale) => ({ params: { locale } }));
+
+const locale = Astro.params.locale as Locale;
+const dictionary = getDictionary(locale);
+
+const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
+const CONTRIBUTING_URL = `${GITHUB_REPOSITORY_URL}/blob/main/CONTRIBUTING.md`;
+const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
+---
+
+<BaseLayout
+  locale={locale}
+  pathname={`/${locale}/contribute`}
+  title={`Dondeteveo | ${dictionary.contributeTitle}`}
+  description={dictionary.contributeIntro}
+  eyebrow={dictionary.contributeTitle}
+>
+  <div
+    class="max-w-3xl space-y-8"
+    style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
+  >
+    <div>
+      <h1
+        class="fade-in font-display text-5xl font-bold uppercase"
+        style="color: var(--color-accent); animation-delay: 0ms;"
+      >
+        {dictionary.contributeTitle}
+      </h1>
+      <p
+        class="fade-in mt-4 font-mono text-base leading-8"
+        style="color: var(--color-muted); animation-delay: 100ms;"
+      >
+        {dictionary.contributeIntro}
+      </p>
+    </div>
+
+    <div class="fade-in" style="animation-delay: 220ms;">
+      <h2
+        class="font-display text-2xl font-bold uppercase"
+        style="color: var(--color-text);"
+      >
+        {dictionary.contributeViaGithub}
+      </h2>
+      <p
+        class="mt-2 font-mono text-sm leading-7"
+        style="color: var(--color-muted);"
+      >
+        {dictionary.contributeViaGithubBody}
+      </p>
+      <a
+        href={CONTRIBUTING_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-3 inline-flex font-mono text-sm transition"
+        style="color: var(--color-accent);"
+        onmouseover="this.style.opacity='0.7'"
+        onmouseout="this.style.opacity='1'"
+      >
+        CONTRIBUTING.md &rarr;
+      </a>
+    </div>
+
+    <div class="fade-in" style="animation-delay: 340ms;">
+      <h2
+        class="font-display text-2xl font-bold uppercase"
+        style="color: var(--color-text);"
+      >
+        {dictionary.contributeTools}
+      </h2>
+      <p
+        class="mt-2 font-mono text-sm leading-7"
+        style="color: var(--color-muted);"
+      >
+        {dictionary.contributeToolsBody}
+      </p>
+      <ul
+        class="mt-3 space-y-2 font-mono text-sm"
+        style="color: var(--color-muted);"
+      >
+        <li>
+          <a
+            href="https://geojson.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition"
+            style="color: var(--color-accent);"
+            onmouseover="this.style.opacity='0.7'"
+            onmouseout="this.style.opacity='1'">geojson.io</a
+          > — {dictionary.contributeToolGeojsonio}
+        </li>
+        <li>
+          <a
+            href="https://www.plotaroute.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition"
+            style="color: var(--color-accent);"
+            onmouseover="this.style.opacity='0.7'"
+            onmouseout="this.style.opacity='1'">plotaroute.com</a
+          > — {dictionary.contributeToolPlotaroute}
+        </li>
+        <li>
+          <a
+            href="https://mapstogpx.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition"
+            style="color: var(--color-accent);"
+            onmouseover="this.style.opacity='0.7'"
+            onmouseout="this.style.opacity='1'">mapstogpx.com</a
+          > — {dictionary.contributeToolMapstogpx}
+        </li>
+      </ul>
+    </div>
+
+    <div class="fade-in" style="animation-delay: 460ms;">
+      <h2
+        class="font-display text-2xl font-bold uppercase"
+        style="color: var(--color-text);"
+      >
+        {dictionary.contributeRequest}
+      </h2>
+      <p
+        class="mt-2 font-mono text-sm leading-7"
+        style="color: var(--color-muted);"
+      >
+        {dictionary.contributeRequestBody}
+      </p>
+      <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:gap-4">
+        <a
+          href={NEW_ISSUE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex font-mono text-sm transition"
+          style="color: var(--color-accent);"
+          onmouseover="this.style.opacity='0.7'"
+          onmouseout="this.style.opacity='1'"
+        >
+          {dictionary.contributeGithubIssue} &rarr;
+        </a>
+        <a
+          href={`mailto:${CONTACT_EMAIL}`}
+          class="inline-flex font-mono text-sm transition"
+          style="color: var(--color-accent);"
+          onmouseover="this.style.opacity='0.7'"
+          onmouseout="this.style.opacity='1'"
+        >
+          {dictionary.contributeEmail} &rarr;
+        </a>
+      </div>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with race data schemas, folder structure, route creation tools (geojson.io, plotaroute, mapstogpx), and step-by-step PR instructions
- Add `/contribute` page (en/es) with sections for GitHub PR contribution, route creation tools, and race request via issue/email
- Add "Can't find your race?" link in race discovery empty state and as a persistent CTA below the race list
- Reference `CONTRIBUTING.md` from `docs/data-race-catalog.md`

Closes #28

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run check` passes (0 errors)
- [x] `npm run build` passes (17 pages)
- [x] `npm run test:unit` passes (16 tests)
- [ ] Manual: navigate to `/en/contribute` and `/es/contribute`, verify content and links
- [ ] Manual: search for a non-existent race in discovery, verify "Can't find your race?" link appears
- [ ] Manual: verify Spanish translations render correctly on `/es/contribute`

No docs update needed beyond the `data-race-catalog.md` reference already included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)