### PR TITLE
feat(i18n): serve Spanish homepage at root and persist locale preference

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@
 
 ## Public Routing
 
-- `/` redirects by browser language to `/en` or `/es`, fallback `/en`
+- `/` serves the Spanish homepage directly; non-Spanish browsers are redirected to `/en` via a client-side script
 - Canonical localized homepages: `/en`, `/es`
 - Listing pages: `/en/races`, `/es/races`
 - Convenience race URLs: `/en/races/<race>`, `/es/races/<race>`

--- a/src/components/astro/LanguageSwitch.astro
+++ b/src/components/astro/LanguageSwitch.astro
@@ -2,6 +2,7 @@
 import {
   LOCALE_ALTERNATES,
   LOCALE_LABELS,
+  LOCALE_STORAGE_KEY,
   type Locale,
 } from "../../lib/config";
 import { switchLocalePath } from "../../lib/format";
@@ -31,15 +32,24 @@ const alternatePath = switchLocalePath(pathname, alternateLocale);
   >
 </a>
 
-<script is:inline>
+<script is:inline define:vars={{ storageKey: LOCALE_STORAGE_KEY }}>
   document.querySelectorAll("[data-preserve-hash-link]").forEach((element) => {
     element.addEventListener("click", (event) => {
       const link = event.currentTarget;
-      if (!(link instanceof HTMLAnchorElement) || !window.location.hash) {
-        return;
+      if (!(link instanceof HTMLAnchorElement)) return;
+
+      const match = link.getAttribute("href")?.match(/^\/(en|es)/);
+      if (match) {
+        try {
+          localStorage.setItem(storageKey, match[1]);
+        } catch {
+          // localStorage may be unavailable
+        }
       }
 
-      link.href = `${link.href}${window.location.hash}`;
+      if (window.location.hash) {
+        link.href = `${link.href}${window.location.hash}`;
+      }
     });
   });
 </script>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,8 +1,7 @@
 export const SUPPORTED_LOCALES = ["en", "es"] as const;
-export const DEFAULT_LOCALE = "en";
+export const DEFAULT_LOCALE = "es";
 export const INDEXABLE_SITE_ORIGIN = "https://dondeteveo.com";
 export const GITHUB_REPOSITORY_URL = "https://github.com/josescgar/dondeteveo";
-export const ROOT_REDIRECT_DELAY_MS = 10;
 export const REQUIRED_CHECK_NAMES = [
   "quality",
   "e2e-smoke",
@@ -23,6 +22,8 @@ export const LOCALE_ALTERNATES: Record<Locale, Locale> = {
   en: "es",
   es: "en",
 };
+
+export const LOCALE_STORAGE_KEY = "dtv-locale";
 
 export const SHARE_FRAGMENT_KEYS = {
   mode: "mode",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,37 +1,172 @@
 ---
-import {
-  DEFAULT_LOCALE,
-  ROOT_REDIRECT_DELAY_MS,
-  SUPPORTED_LOCALES,
-} from "../lib/config";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import DiscoveryListIsland from "../features/race-discovery/DiscoveryListIsland";
+
+import { LOCALE_STORAGE_KEY, SUPPORTED_LOCALES } from "../lib/config";
+import { getDictionary } from "../lib/i18n";
+import { localizeRaceSummary } from "../lib/races/localized";
+import { getRaceSummaries } from "../lib/races/catalog";
+
+const locale = "es" as const;
+const dictionary = getDictionary(locale);
+const races = (await getRaceSummaries()).map((race) =>
+  localizeRaceSummary(race, locale),
+);
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="robots" content="noindex,follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Dondeteveo</title>
-    <script
-      is:inline
-      define:vars={{
-        fallbackLocale: DEFAULT_LOCALE,
-        redirectDelayMs: ROOT_REDIRECT_DELAY_MS,
-        supportedLocales: SUPPORTED_LOCALES,
-      }}
+<BaseLayout
+  locale={locale}
+  pathname={`/${locale}`}
+  title={`Dondeteveo | ${dictionary.directRaceSearch}`}
+  description={dictionary.heroBody}
+>
+  <!-- Section 1: Hero -->
+  <section class="pb-14" style="border-bottom: 1px solid var(--color-line);">
+    <div
+      class="font-mono text-[10px] tracking-[0.32em] uppercase"
+      style="color: var(--color-muted);"
     >
-      const preferredLocale = navigator.languages
-        .map((value) => value.slice(0, 2).toLowerCase())
-        .find((value) => supportedLocales.includes(value));
+      // {dictionary.siteTagline}
+    </div>
+    <div
+      class="font-display mt-3 leading-none font-bold uppercase"
+      style="font-size: clamp(3.5rem, 14vw, 9rem); color: var(--color-text);"
+    >
+      DONDETEVEO
+    </div>
+    <h1
+      class="font-display mt-4 font-bold uppercase sm:text-5xl"
+      style="font-size: clamp(1.5rem, 5vw, 3rem); color: var(--color-accent);"
+    >
+      {dictionary.heroTitle}
+    </h1>
+    <p
+      class="mt-4 max-w-lg font-mono text-base leading-8"
+      style="color: var(--color-muted);"
+    >
+      {dictionary.heroBody}
+    </p>
+    <div class="mt-7">
+      <a
+        href={`/${locale}/races`}
+        class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
+        style="background-color: var(--color-coral); color: var(--color-text);"
+        onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"
+        onmouseout="this.style.backgroundColor='var(--color-coral)'"
+      >
+        {dictionary.directRaceSearch}
+      </a>
+    </div>
+  </section>
 
-      window.setTimeout(() => {
-        window.location.replace(`/${preferredLocale ?? fallbackLocale}`);
-      }, redirectDelayMs);
-    </script>
-  </head>
-  <body>
-    <p>Redirecting...</p>
-    <p><a href={`/${DEFAULT_LOCALE}`}>Continue in English</a></p>
-  </body>
-</html>
+  <!-- Section 2: Feature row -->
+  <section class="py-14" style="border-bottom: 1px solid var(--color-line);">
+    <div class="grid gap-8 sm:grid-cols-3">
+      <div class="flex gap-4">
+        <div
+          class="w-0.5 self-stretch"
+          style="background-color: var(--color-accent);"
+        >
+        </div>
+        <div>
+          <div
+            class="font-display text-base font-bold uppercase"
+            style="color: var(--color-accent);"
+          >
+            {dictionary.searchFirstTitle}
+          </div>
+          <p
+            class="mt-2 font-mono text-sm leading-7"
+            style="color: var(--color-muted);"
+          >
+            {dictionary.searchFirstBody}
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <div
+          class="w-0.5 self-stretch"
+          style="background-color: var(--color-accent);"
+        >
+        </div>
+        <div>
+          <div
+            class="font-display text-base font-bold uppercase"
+            style="color: var(--color-accent);"
+          >
+            {dictionary.justOpenTitle}
+          </div>
+          <p
+            class="mt-2 font-mono text-sm leading-7"
+            style="color: var(--color-muted);"
+          >
+            {dictionary.justOpenBody}
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <div
+          class="w-0.5 self-stretch"
+          style="background-color: var(--color-accent);"
+        >
+        </div>
+        <div>
+          <div
+            class="font-display text-base font-bold uppercase"
+            style="color: var(--color-accent);"
+          >
+            {dictionary.shareReadyTitle}
+          </div>
+          <p
+            class="mt-2 font-mono text-sm leading-7"
+            style="color: var(--color-muted);"
+          >
+            {dictionary.shareReadyBody}
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: Race search -->
+  <section id="race-search" class="mt-14 scroll-mt-8">
+    <div
+      class="mb-5 font-mono text-[10px] tracking-[0.32em] uppercase"
+      style="color: var(--color-muted);"
+    >
+      // {dictionary.directRaceSearch}
+    </div>
+    <DiscoveryListIsland locale={locale} races={races} client:load />
+  </section>
+
+  <script
+    is:inline
+    define:vars={{
+      supportedLocales: SUPPORTED_LOCALES,
+      storageKey: LOCALE_STORAGE_KEY,
+    }}
+  >
+    let saved;
+    try {
+      saved = localStorage.getItem(storageKey);
+    } catch {
+      // localStorage may be unavailable
+    }
+
+    if (saved && supportedLocales.includes(saved)) {
+      if (saved !== "es") {
+        window.location.replace(`/${saved}`);
+      }
+    } else {
+      const isSpanish = navigator.languages.some(
+        (lang) => lang.slice(0, 2).toLowerCase() === "es",
+      );
+      if (!isSpanish) {
+        const preferred = navigator.languages
+          .map((lang) => lang.slice(0, 2).toLowerCase())
+          .find((code) => supportedLocales.includes(code));
+        window.location.replace(`/${preferred ?? "en"}`);
+      }
+    }
+  </script>
+</BaseLayout>

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -10,11 +10,46 @@ const expectNoHorizontalOverflow = async (
   expect(hasOverflow).toBe(false);
 };
 
-test("root redirects to a localized homepage", async ({ page }) => {
+test("root serves the Spanish homepage for Spanish browsers", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ locale: "es-ES" });
+  const page = await context.newPage();
+
   await page.goto("/");
-  await page.waitForURL(/\/(en|es)$/);
 
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page).toHaveURL("/");
+
+  await context.close();
+});
+
+test("root redirects to /en for English browsers", async ({ browser }) => {
+  const context = await browser.newContext({ locale: "en-US" });
+  const page = await context.newPage();
+
+  await page.goto("/");
+  await page.waitForURL(/\/en$/);
+
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  await context.close();
+});
+
+test("root stays on / for English browser with saved Spanish preference", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ locale: "en-US" });
+  const page = await context.newPage();
+
+  await page.goto("/en");
+  await page.evaluate(() => localStorage.setItem("dtv-locale", "es"));
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page).toHaveURL("/");
+
+  await context.close();
 });
 
 test("race discovery reaches a race page and share flow", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Root `/` now serves the Spanish homepage directly instead of redirecting, eliminating the flash for Spanish-speaking users
- Non-Spanish browsers are redirected to `/en` via client-side script (same behavior as before for them)
- Language switch saves the user's locale choice to `localStorage` (`dtv-locale` key), so returning visits honor the explicit preference over browser language detection
- Added e2e test verifying an English browser with saved Spanish preference stays on `/`

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run test:unit` — 16 tests pass
- [x] `npm run test:e2e` — 11 tests pass (including new localStorage test)
- [ ] Manual: English browser → `/` redirects to `/en` → click language switch to Spanish → revisit `/` → stays on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)