### PR TITLE
fix(share): validate finish time and pace input format (#34)

### DIFF
--- a/src/features/share-planner/SharePlannerIsland.tsx
+++ b/src/features/share-planner/SharePlannerIsland.tsx
@@ -3,7 +3,12 @@ import { useState } from "preact/hooks";
 import type { Locale } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
 import type { ShareMode } from "../../lib/share/share-state";
-import { buildShareHref, getDefaultShareValue } from "./share-planner.logic";
+import {
+  buildShareHref,
+  getDefaultShareValue,
+  isValidShareValue,
+  maskTimeInput,
+} from "./share-planner.logic";
 
 type Props = {
   locale: Locale;
@@ -21,10 +26,42 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
   const [mode, setMode] = useState<ShareMode>("pace");
   const [value, setValue] = useState(getDefaultShareValue("pace"));
   const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   const handleModeChange = (nextMode: ShareMode) => {
     setMode(nextMode);
     setValue(getDefaultShareValue(nextMode));
+    setError(null);
+  };
+
+  const handleValueFocus = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    input.value = "";
+    setValue("");
+    setError(null);
+  };
+
+  const handleValueInput = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    const masked = maskTimeInput(input.value, mode);
+    input.value = masked;
+    setValue(masked);
+    if (error && isValidShareValue(mode, masked)) {
+      setError(null);
+    }
+  };
+
+  const handleLinkClick = (event: Event) => {
+    if (isValidShareValue(mode, value)) {
+      setError(null);
+      return;
+    }
+    event.preventDefault();
+    setError(
+      mode === "pace"
+        ? dictionary.invalidPaceFormat
+        : dictionary.invalidFinishTimeFormat,
+    );
   };
 
   const href = buildShareHref({ locale, raceSlug, year, mode, value, name });
@@ -79,21 +116,28 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
           <input
             type="text"
             value={value}
-            onInput={(event) => setValue(event.currentTarget.value)}
+            onInput={handleValueInput}
             placeholder={getDefaultShareValue(mode)}
             inputMode="numeric"
-            pattern={
-              mode === "pace" ? "\\d{1,2}:\\d{2}" : "\\d{1,2}:\\d{2}:\\d{2}"
-            }
             class={fieldInputClass}
             style={fieldInputStyle}
-            onFocus={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-accent)")
-            }
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = "var(--color-accent)";
+              handleValueFocus(e);
+            }}
             onBlur={(e) =>
               (e.currentTarget.style.borderColor = "var(--color-line-solid)")
             }
           />
+          {error && (
+            <span
+              class="font-mono text-xs"
+              style="color: var(--color-coral-deep);"
+              role="alert"
+            >
+              {error}
+            </span>
+          )}
         </label>
       </div>
       <label class="mt-4 flex flex-col gap-1.5">
@@ -119,6 +163,7 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
       </label>
       <a
         href={href}
+        onClick={handleLinkClick}
         class="mt-6 inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
         style="background-color: var(--color-coral); color: var(--color-text);"
         onMouseOver={(e) => {

--- a/src/features/share-planner/share-planner.logic.ts
+++ b/src/features/share-planner/share-planner.logic.ts
@@ -1,5 +1,7 @@
 import { buildSharePath } from "../../lib/format";
 import {
+  parseFinishTimeToMinutes,
+  parsePaceToMinutesPerKm,
   serializeShareState,
   type ShareMode,
 } from "../../lib/share/share-state";
@@ -32,4 +34,22 @@ export const buildShareHref = ({
   });
 
   return `${buildSharePath(locale, raceSlug, year)}#${fragment}`;
+};
+
+export const isValidShareValue = (mode: ShareMode, value: string): boolean =>
+  mode === "pace"
+    ? parsePaceToMinutesPerKm(value) !== null
+    : parseFinishTimeToMinutes(value) !== null;
+
+export const maskTimeInput = (raw: string, mode: ShareMode): string => {
+  const digits = raw.replace(/\D/g, "");
+  const maxDigits = mode === "pace" ? 4 : 6;
+  const truncated = digits.slice(0, maxDigits);
+
+  // Auto-insert colons after every 2-digit group.
+  const parts: string[] = [];
+  for (let i = 0; i < truncated.length; i += 2) {
+    parts.push(truncated.slice(i, i + 2));
+  }
+  return parts.join(":");
 };

--- a/src/features/share-planner/share-planner.test.ts
+++ b/src/features/share-planner/share-planner.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { buildShareHref, getDefaultShareValue } from "./share-planner.logic";
+import {
+  buildShareHref,
+  getDefaultShareValue,
+  isValidShareValue,
+  maskTimeInput,
+} from "./share-planner.logic";
 
 describe("share planner logic", () => {
   it("builds a share href with fragment state", () => {
@@ -20,5 +25,73 @@ describe("share planner logic", () => {
   it("uses mode-specific default values", () => {
     expect(getDefaultShareValue("pace")).toBe("05:00");
     expect(getDefaultShareValue("finish")).toBe("01:45:00");
+  });
+});
+
+describe("isValidShareValue", () => {
+  it("accepts valid pace values", () => {
+    expect(isValidShareValue("pace", "05:00")).toBe(true);
+    expect(isValidShareValue("pace", "4:30")).toBe(true);
+    expect(isValidShareValue("pace", "12:59")).toBe(true);
+  });
+
+  it("rejects invalid pace values", () => {
+    expect(isValidShareValue("pace", "")).toBe(false);
+    expect(isValidShareValue("pace", "abc")).toBe(false);
+    expect(isValidShareValue("pace", "5:60")).toBe(false);
+    expect(isValidShareValue("pace", "00:00")).toBe(false);
+    expect(isValidShareValue("pace", "05:0")).toBe(false);
+    expect(isValidShareValue("pace", "05:000")).toBe(false);
+  });
+
+  it("accepts valid finish time values", () => {
+    expect(isValidShareValue("finish", "01:45:00")).toBe(true);
+    expect(isValidShareValue("finish", "3:30:00")).toBe(true);
+    expect(isValidShareValue("finish", "0:30:00")).toBe(true);
+  });
+
+  it("rejects invalid finish time values", () => {
+    expect(isValidShareValue("finish", "")).toBe(false);
+    expect(isValidShareValue("finish", "abc")).toBe(false);
+    expect(isValidShareValue("finish", "01:60:00")).toBe(false);
+    expect(isValidShareValue("finish", "01:00:60")).toBe(false);
+    expect(isValidShareValue("finish", "00:00:00")).toBe(false);
+    expect(isValidShareValue("finish", "1:45")).toBe(false);
+  });
+});
+
+describe("maskTimeInput", () => {
+  it("strips non-digit characters", () => {
+    expect(maskTimeInput("ab12cd", "pace")).toBe("12");
+    expect(maskTimeInput("a1b2c3d4", "finish")).toBe("12:34");
+  });
+
+  it("auto-inserts colon for pace every 2 digits", () => {
+    expect(maskTimeInput("0", "pace")).toBe("0");
+    expect(maskTimeInput("05", "pace")).toBe("05");
+    expect(maskTimeInput("053", "pace")).toBe("05:3");
+    expect(maskTimeInput("0500", "pace")).toBe("05:00");
+  });
+
+  it("auto-inserts colons for finish time every 2 digits", () => {
+    expect(maskTimeInput("0", "finish")).toBe("0");
+    expect(maskTimeInput("01", "finish")).toBe("01");
+    expect(maskTimeInput("014", "finish")).toBe("01:4");
+    expect(maskTimeInput("0145", "finish")).toBe("01:45");
+    expect(maskTimeInput("01450", "finish")).toBe("01:45:0");
+    expect(maskTimeInput("014500", "finish")).toBe("01:45:00");
+  });
+
+  it("truncates pace to 4 digits max", () => {
+    expect(maskTimeInput("05001", "pace")).toBe("05:00");
+  });
+
+  it("truncates finish time to 6 digits max", () => {
+    expect(maskTimeInput("0145001", "finish")).toBe("01:45:00");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(maskTimeInput("", "pace")).toBe("");
+    expect(maskTimeInput("", "finish")).toBe("");
   });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -82,6 +82,8 @@ type Dictionary = {
   copyLink: string;
   copiedLink: string;
   footerPunchline: string;
+  invalidFinishTimeFormat: string;
+  invalidPaceFormat: string;
   shareLinkTitle: string;
 };
 
@@ -184,6 +186,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     copyLink: "Copy link",
     copiedLink: "Copied!",
     footerPunchline: "Made by a runner, for runners",
+    invalidFinishTimeFormat: "Enter a valid finish time (HH:MM:SS)",
+    invalidPaceFormat: "Enter a valid pace (MM:SS)",
     shareLinkTitle: "Share this page",
   },
   es: {
@@ -287,6 +291,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     copyLink: "Copiar enlace",
     copiedLink: "¡Copiado!",
     footerPunchline: "Hecho por un corredor, para corredores",
+    invalidFinishTimeFormat: "Introduce un tiempo válido (HH:MM:SS)",
+    invalidPaceFormat: "Introduce un ritmo válido (MM:SS)",
     shareLinkTitle: "Comparte esta página",
   },
 };


### PR DESCRIPTION
## Summary
- Add input masking to pace and finish time fields: only digits accepted, colons auto-inserted every 2 digits, max length enforced (MM:SS for pace, HH:MM:SS for finish)
- Field clears on focus so entry always starts fresh — no mid-edit cursor issues
- Validate on link click using existing parse functions; block navigation and show inline error when invalid

## Test plan
- [ ] Enter digits in pace field → auto-formats as MM:SS, non-digits rejected
- [ ] Enter digits in finish time field → auto-formats as HH:MM:SS, non-digits rejected
- [ ] Click generate link with incomplete/invalid value → error shown, navigation blocked
- [ ] Click generate link with valid value → navigates to share page
- [ ] Switch mode → error clears, default value restored
- [ ] Focus field with existing value → field clears for fresh entry

## Docs
No docs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)