### PR TITLE
feat(share): support races longer than 24 hours (#50)

### DIFF
--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -73,8 +73,15 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
   const predictedPoints = paceMinutesPerKm
     ? buildPredictedPoints(points, paceMinutesPerKm, edition.meta.startTime)
     : [];
+  const formatDayOffset = (n: number) =>
+    dictionary.dayOffsetLabel.replace("{n}", String(n));
   const pointDetails = Object.fromEntries(
-    predictedPoints.map((point) => [point.id, point.predictedTime]),
+    predictedPoints.map((point) => [
+      point.id,
+      point.dayOffset > 0
+        ? `${point.predictedTime} (${formatDayOffset(point.dayOffset)})`
+        : point.predictedTime,
+    ]),
   );
 
   if (!shareState || paceMinutesPerKm === null) {
@@ -234,10 +241,18 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
                 {formatDistance(point.distanceKm, locale)}
               </div>
               <div
-                class="mt-4 font-mono leading-none font-medium"
+                class="mt-4 flex items-baseline gap-2 font-mono leading-none font-medium"
                 style={`font-size: clamp(2.8rem, 8vw, 4rem); color: var(--color-coral); letter-spacing: -0.02em;`}
               >
                 {point.predictedTime}
+                {point.dayOffset > 0 && (
+                  <span
+                    class="font-mono text-xs font-normal tracking-wide"
+                    style="color: var(--color-muted);"
+                  >
+                    {formatDayOffset(point.dayOffset)}
+                  </span>
+                )}
               </div>
             </article>
           ))}

--- a/src/features/share-view/share-view.logic.ts
+++ b/src/features/share-view/share-view.logic.ts
@@ -1,5 +1,6 @@
 import type { RacePointFeature } from "../../lib/races/schemas";
 import {
+  dayOffsetFromMinutes,
   formatMinutesAsClock,
   parseFinishTimeToMinutes,
   parsePaceToMinutesPerKm,
@@ -12,6 +13,7 @@ export type PredictedPoint = {
   kind: "split" | "cheer-point";
   distanceKm: number;
   predictedTime: string;
+  dayOffset: number;
 };
 
 export const resolvePaceMinutesPerKm = (
@@ -42,13 +44,16 @@ export const buildPredictedPoints = (
 ): PredictedPoint[] => {
   const baseMinutes = startClockMinutes(raceStartTime);
 
-  return points.map((point) => ({
-    id: point.properties.id,
-    label: point.properties.label,
-    kind: point.properties.kind,
-    distanceKm: point.properties.distanceKm,
-    predictedTime: formatMinutesAsClock(
-      baseMinutes + point.properties.distanceKm * paceMinutesPerKm,
-    ),
-  }));
+  return points.map((point) => {
+    const clockMinutes =
+      baseMinutes + point.properties.distanceKm * paceMinutesPerKm;
+    return {
+      id: point.properties.id,
+      label: point.properties.label,
+      kind: point.properties.kind,
+      distanceKm: point.properties.distanceKm,
+      predictedTime: formatMinutesAsClock(clockMinutes),
+      dayOffset: dayOffsetFromMinutes(clockMinutes),
+    };
+  });
 };

--- a/src/features/share-view/share-view.test.ts
+++ b/src/features/share-view/share-view.test.ts
@@ -29,5 +29,35 @@ describe("share view logic", () => {
 
     const predicted = buildPredictedPoints(points, 5, "09:00");
     expect(predicted[0].predictedTime).toBe("09:25");
+    expect(predicted[0].dayOffset).toBe(0);
+  });
+
+  it("wraps times past midnight and sets dayOffset for overnight races", () => {
+    const points = [
+      {
+        properties: {
+          id: "km-80",
+          label: "80K split",
+          kind: "split",
+          distanceKm: 80,
+        },
+      },
+      {
+        properties: {
+          id: "km-160",
+          label: "160K split",
+          kind: "split",
+          distanceKm: 160,
+        },
+      },
+    ] as never;
+
+    // Start at 23:00, pace 12 min/km → 80 km = 960 min → clock = 23:00 + 16:00 = 39:00 → wraps to 15:00, dayOffset 1
+    const predicted = buildPredictedPoints(points, 12, "23:00");
+    expect(predicted[0].predictedTime).toBe("15:00");
+    expect(predicted[0].dayOffset).toBe(1);
+    // 160 km = 1920 min → clock = 23:00 + 32:00 = 55:00 → wraps to 07:00, dayOffset 2
+    expect(predicted[1].predictedTime).toBe("07:00");
+    expect(predicted[1].dayOffset).toBe(2);
   });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -81,6 +81,7 @@ type Dictionary = {
   copiedToClipboard: string;
   copyLink: string;
   copiedLink: string;
+  dayOffsetLabel: string;
   footerPunchline: string;
   invalidFinishTimeFormat: string;
   invalidPaceFormat: string;
@@ -185,6 +186,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     copiedToClipboard: "Copied to the clipboard",
     copyLink: "Copy link",
     copiedLink: "Copied!",
+    dayOffsetLabel: "D+{n}",
     footerPunchline: "Made by a runner, for runners",
     invalidFinishTimeFormat: "Enter a valid finish time (HH:MM:SS)",
     invalidPaceFormat: "Enter a valid pace (MM:SS)",
@@ -290,6 +292,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     copiedToClipboard: "Copiado al portapapeles",
     copyLink: "Copiar enlace",
     copiedLink: "¡Copiado!",
+    dayOffsetLabel: "D+{n}",
     footerPunchline: "Hecho por un corredor, para corredores",
     invalidFinishTimeFormat: "Introduce un tiempo válido (HH:MM:SS)",
     invalidPaceFormat: "Introduce un ritmo válido (MM:SS)",

--- a/src/lib/share/share-state.test.ts
+++ b/src/lib/share/share-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  dayOffsetFromMinutes,
   formatMinutesAsClock,
   parseFinishTimeToMinutes,
   parsePaceToMinutesPerKm,
@@ -40,5 +41,17 @@ describe("share state helpers", () => {
 
   it("formats minutes as a clock string", () => {
     expect(formatMinutesAsClock(612)).toBe("10:12");
+  });
+
+  it("wraps clock times past midnight", () => {
+    expect(formatMinutesAsClock(1500)).toBe("01:00");
+    expect(formatMinutesAsClock(2880)).toBe("00:00");
+  });
+
+  it("computes day offset from minutes", () => {
+    expect(dayOffsetFromMinutes(600)).toBe(0);
+    expect(dayOffsetFromMinutes(1440)).toBe(1);
+    expect(dayOffsetFromMinutes(1500)).toBe(1);
+    expect(dayOffsetFromMinutes(2880)).toBe(2);
   });
 });

--- a/src/lib/share/share-state.ts
+++ b/src/lib/share/share-state.ts
@@ -99,11 +99,14 @@ export const parsePaceToMinutesPerKm = (value: string): number | null => {
 };
 
 export const formatMinutesAsClock = (value: number): string => {
-  const roundedMinutes = Math.floor(value);
-  const hours = Math.floor(roundedMinutes / 60)
+  const wrappedMinutes = Math.floor(value) % 1440;
+  const hours = Math.floor(wrappedMinutes / 60)
     .toString()
     .padStart(2, "0");
-  const minutes = (roundedMinutes % 60).toString().padStart(2, "0");
+  const minutes = (wrappedMinutes % 60).toString().padStart(2, "0");
 
   return `${hours}:${minutes}`;
 };
+
+export const dayOffsetFromMinutes = (value: number): number =>
+  Math.floor(value / 1440);


### PR DESCRIPTION
## Summary
- Wrap `formatMinutesAsClock` at 24h (mod 1440) so ultra-race checkpoint times produce valid clock values
- Add `dayOffsetFromMinutes` helper and `dayOffset` field to `PredictedPoint`
- Display "D+1" / "D+2" day-offset indicator on timing cards and map popups for overnight races
- Add i18n `dayOffsetLabel` string (same format en/es — standard race timing notation)

## Test plan
- [x] `formatMinutesAsClock(1500)` → `"01:00"` (wraps past midnight)
- [x] `formatMinutesAsClock(2880)` → `"00:00"` (wraps 2 full days)
- [x] `dayOffsetFromMinutes` returns correct day for 0, 1, 2+ days
- [x] `buildPredictedPoints` with 23:00 start + slow pace → correct wrapped times and dayOffsets
- [x] Existing test `formatMinutesAsClock(612)` → `"10:12"` still passes
- [x] Full validation: lint, format, typecheck, unit tests, build — all green

No docs needed — no material change to architecture, workflow, or data model.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)