### PR TITLE
fix(ui): align timing card predicted times across grid rows

### DIFF
--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -407,7 +407,7 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
             <button
               key={point.id}
               type="button"
-              class="timing-card w-full text-left"
+              class="timing-card flex w-full flex-col text-left"
               data-predicted-point-card
               data-point-id={point.id}
               data-selected={selectedPointId === point.id ? "true" : "false"}
@@ -419,25 +419,27 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
                   : "var(--color-line)"
               }; padding: 1.5rem; cursor: pointer; width: 100%;`}
             >
-              <div
-                class="font-mono text-[9px] tracking-[0.32em] uppercase"
-                style="color: var(--color-muted);"
-              >
-                {point.kind === "split"
-                  ? dictionary.splitLabel
-                  : dictionary.cheerPointLabel}
-              </div>
-              <h4
-                class="font-display mt-1 text-xl leading-tight font-bold uppercase"
-                style="color: var(--color-text);"
-              >
-                {point.label}
-              </h4>
-              <div
-                class="mt-1 font-mono text-xs"
-                style="color: var(--color-muted);"
-              >
-                {formatDistance(point.distanceKm, locale)}
+              <div class="flex-1">
+                <div
+                  class="font-mono text-[9px] tracking-[0.32em] uppercase"
+                  style="color: var(--color-muted);"
+                >
+                  {point.kind === "split"
+                    ? dictionary.splitLabel
+                    : dictionary.cheerPointLabel}
+                </div>
+                <h4
+                  class="font-display mt-1 text-xl leading-tight font-bold uppercase"
+                  style="color: var(--color-text);"
+                >
+                  {point.label}
+                </h4>
+                <div
+                  class="mt-1 font-mono text-xs"
+                  style="color: var(--color-muted);"
+                >
+                  {formatDistance(point.distanceKm, locale)}
+                </div>
               </div>
               <div
                 class="mt-4 flex items-baseline gap-2 font-mono leading-none font-medium"


### PR DESCRIPTION
## Summary
- Fixes vertical misalignment of predicted times on share screen timing cards when card titles have different lengths
- Converts each timing card to a flex column layout with a growable top section, pushing the time display to a consistent vertical position across cards in the same row

Closes #18

## Docs
No docs needed

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint && npm run format:check && npm run check` pass
- [x] `npm run test:unit` passes
- [ ] Visual inspection: open a share URL and verify all timing cards align consistently across different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)