### PR TITLE
fix(discovery): contain arrow within row background

### DIFF
--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -128,7 +128,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             return (
               <a
                 href={card.href}
-                class="race-row group flex items-center justify-between gap-4 px-0 py-4 transition-colors"
+                class="race-row group flex items-center justify-between gap-4 py-4 pr-2 transition-colors"
                 style="border-bottom: 1px solid var(--color-line);"
                 onMouseOver={(e) => {
                   (e.currentTarget as HTMLAnchorElement).style.backgroundColor =


### PR DESCRIPTION
## Summary

- Replace `px-0` with `pr-2` on the race result row `<a>` element
- Adds 8px right padding so the `group-hover:translate-x-0.5` arrow animation stays within the row background boundary

Closes #43

## Test plan

- [x] Lint, format check, type check, unit tests, build all pass
- [ ] Visual check: open race listing on desktop, confirm arrow stays within row background at rest and on hover

## Docs

No docs needed — UI-only fix with no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)