### PR TITLE
feat(share-planner): add validation to nickname input

### DIFF
--- a/src/features/share-planner/SharePlannerIsland.tsx
+++ b/src/features/share-planner/SharePlannerIsland.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useRef, useState } from "preact/hooks";
 
 import type { Locale } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
@@ -8,6 +8,8 @@ import {
   getDefaultShareValue,
   isValidShareValue,
   maskTimeInput,
+  NICKNAME_MAX_LENGTH,
+  validateNickname,
 } from "./share-planner.logic";
 
 type Props = {
@@ -27,11 +29,14 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
   const [value, setValue] = useState(getDefaultShareValue("pace"));
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const linkRef = useRef<HTMLAnchorElement>(null);
 
   const handleModeChange = (nextMode: ShareMode) => {
     setMode(nextMode);
     setValue(getDefaultShareValue(nextMode));
     setError(null);
+    setNameError(null);
   };
 
   const handleValueFocus = (event: Event) => {
@@ -51,23 +56,46 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
     }
   };
 
-  const handleLinkClick = (event: Event) => {
-    if (isValidShareValue(mode, value)) {
-      setError(null);
+  const handleNameInput = (event: Event) => {
+    const next = (event.currentTarget as HTMLInputElement).value;
+    setName(next);
+    const result = validateNickname(next);
+    if (result.valid) {
+      setNameError(null);
+    } else {
+      setNameError(
+        result.reason === "invalid-characters"
+          ? dictionary.invalidNicknameCharacters
+          : dictionary.invalidNicknameLength,
+      );
+    }
+  };
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault();
+
+    if (nameError) return;
+
+    if (!isValidShareValue(mode, value)) {
+      setError(
+        mode === "pace"
+          ? dictionary.invalidPaceFormat
+          : dictionary.invalidFinishTimeFormat,
+      );
       return;
     }
-    event.preventDefault();
-    setError(
-      mode === "pace"
-        ? dictionary.invalidPaceFormat
-        : dictionary.invalidFinishTimeFormat,
-    );
+
+    setError(null);
+    linkRef.current?.click();
   };
 
   const href = buildShareHref({ locale, raceSlug, year, mode, value, name });
 
   return (
-    <div style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;">
+    <form
+      onSubmit={handleSubmit}
+      style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
+    >
       <div
         class="font-mono text-[10px] tracking-[0.3em] uppercase"
         style="color: var(--color-accent);"
@@ -150,7 +178,8 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
         <input
           type="text"
           value={name}
-          onInput={(event) => setName(event.currentTarget.value)}
+          maxLength={NICKNAME_MAX_LENGTH}
+          onInput={handleNameInput}
           class={fieldInputClass}
           style={fieldInputStyle}
           onFocus={(e) =>
@@ -160,10 +189,29 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
             (e.currentTarget.style.borderColor = "var(--color-line-solid)")
           }
         />
+        <div class="flex items-baseline justify-between gap-2">
+          {nameError ? (
+            <span
+              class="font-mono text-xs"
+              style="color: var(--color-coral-deep);"
+              role="alert"
+            >
+              {nameError}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span
+            class={`shrink-0 font-mono text-[10px]${name.length === 0 ? "invisible" : ""}`}
+            style={`color: var(${name.length >= NICKNAME_MAX_LENGTH ? "--color-coral-deep" : "--color-muted"});`}
+          >
+            {NICKNAME_MAX_LENGTH - name.length}
+          </span>
+        </div>
       </label>
       <a
+        ref={linkRef}
         href={href}
-        onClick={handleLinkClick}
         class="mt-6 inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
         style="background-color: var(--color-coral); color: var(--color-text);"
         onMouseOver={(e) => {
@@ -177,6 +225,7 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
       >
         {dictionary.generateShareLink}
       </a>
-    </div>
+      <button type="submit" class="hidden" tabIndex={-1} aria-hidden="true" />
+    </form>
   );
 }

--- a/src/features/share-planner/share-planner.logic.ts
+++ b/src/features/share-planner/share-planner.logic.ts
@@ -7,6 +7,23 @@ import {
 } from "../../lib/share/share-state";
 import type { Locale } from "../../lib/config";
 
+export const NICKNAME_MAX_LENGTH = 30;
+
+const NICKNAME_PATTERN = /^[\p{L}\p{N}\s'.-]+$/u;
+
+export type NicknameValidationResult =
+  | { valid: true }
+  | { valid: false; reason: "invalid-characters" | "too-long" };
+
+export const validateNickname = (name: string): NicknameValidationResult => {
+  if (name.length === 0) return { valid: true };
+  if (!NICKNAME_PATTERN.test(name))
+    return { valid: false, reason: "invalid-characters" };
+  if (name.length > NICKNAME_MAX_LENGTH)
+    return { valid: false, reason: "too-long" };
+  return { valid: true };
+};
+
 export type SharePlannerInput = {
   locale: Locale;
   raceSlug: string;

--- a/src/features/share-planner/share-planner.test.ts
+++ b/src/features/share-planner/share-planner.test.ts
@@ -5,6 +5,7 @@ import {
   getDefaultShareValue,
   isValidShareValue,
   maskTimeInput,
+  validateNickname,
 } from "./share-planner.logic";
 
 describe("share planner logic", () => {
@@ -57,6 +58,65 @@ describe("isValidShareValue", () => {
     expect(isValidShareValue("finish", "01:00:60")).toBe(false);
     expect(isValidShareValue("finish", "00:00:00")).toBe(false);
     expect(isValidShareValue("finish", "1:45")).toBe(false);
+  });
+});
+
+describe("validateNickname", () => {
+  it("accepts empty string", () => {
+    expect(validateNickname("")).toEqual({ valid: true });
+  });
+
+  it("accepts alphanumeric names", () => {
+    expect(validateNickname("Runner42")).toEqual({ valid: true });
+  });
+
+  it("accepts accented characters", () => {
+    expect(validateNickname("José")).toEqual({ valid: true });
+  });
+
+  it("accepts spaces", () => {
+    expect(validateNickname("José López")).toEqual({ valid: true });
+  });
+
+  it("accepts basic punctuation: apostrophe, period, hyphen", () => {
+    expect(validateNickname("O'Brien")).toEqual({ valid: true });
+    expect(validateNickname("Dr. Smith")).toEqual({ valid: true });
+    expect(validateNickname("Jean-Luc")).toEqual({ valid: true });
+  });
+
+  it("accepts name at exactly 30 characters", () => {
+    expect(validateNickname("a".repeat(30))).toEqual({ valid: true });
+  });
+
+  it("rejects name over 30 characters", () => {
+    expect(validateNickname("a".repeat(31))).toEqual({
+      valid: false,
+      reason: "too-long",
+    });
+  });
+
+  it("rejects URL-problematic characters", () => {
+    for (const char of ["#", "&", "=", "+"]) {
+      expect(validateNickname(`foo${char}bar`)).toEqual({
+        valid: false,
+        reason: "invalid-characters",
+      });
+    }
+  });
+
+  it("rejects control characters", () => {
+    expect(validateNickname("foo\x00bar")).toEqual({
+      valid: false,
+      reason: "invalid-characters",
+    });
+  });
+
+  it("checks characters before length", () => {
+    const longInvalid = "#".repeat(31);
+    expect(validateNickname(longInvalid)).toEqual({
+      valid: false,
+      reason: "invalid-characters",
+    });
   });
 });
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -86,6 +86,8 @@ type Dictionary = {
   footerPunchline: string;
   importantRaceNote: string;
   invalidFinishTimeFormat: string;
+  invalidNicknameCharacters: string;
+  invalidNicknameLength: string;
   invalidPaceFormat: string;
   shareLinkTitle: string;
   dismissRoutePoint: string;
@@ -201,6 +203,9 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     footerPunchline: "Made by a runner, for runners",
     importantRaceNote: "Important race note",
     invalidFinishTimeFormat: "Enter a valid finish time (HH:MM:SS)",
+    invalidNicknameCharacters:
+      "Only letters, numbers, spaces, and characters (', ., -) allowed",
+    invalidNicknameLength: "Nickname must be 30 characters or fewer",
     invalidPaceFormat: "Enter a valid pace (MM:SS)",
     shareLinkTitle: "Share this page",
     dismissRoutePoint: "Dismiss selected point",
@@ -317,6 +322,9 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     footerPunchline: "Hecho por un corredor, para corredores",
     importantRaceNote: "Nota importante",
     invalidFinishTimeFormat: "Introduce un tiempo válido (HH:MM:SS)",
+    invalidNicknameCharacters:
+      "Solo se permiten letras, números, espacios y caracteres (', ., -)",
+    invalidNicknameLength: "El apodo debe tener 30 caracteres o menos",
     invalidPaceFormat: "Introduce un ritmo válido (MM:SS)",
     shareLinkTitle: "Comparte esta página",
     dismissRoutePoint: "Cerrar punto seleccionado",

--- a/src/lib/share/share-state.ts
+++ b/src/lib/share/share-state.ts
@@ -7,7 +7,12 @@ const shareModeSchema = z.enum(["pace", "finish"]);
 const fragmentSchema = z.object({
   mode: shareModeSchema,
   value: z.string().min(1),
-  name: z.string().trim().max(40).optional(),
+  name: z
+    .string()
+    .trim()
+    .max(30)
+    .regex(/^[\p{L}\p{N}\s'.-]*$/u)
+    .optional(),
 });
 
 export type ShareMode = z.infer<typeof shareModeSchema>;


### PR DESCRIPTION
## Summary

- Add realtime nickname validation (Unicode letters, digits, spaces, `'`, `.`, `-`) with inline error display and remaining-character counter
- Wrap share planner in a `<form>` so pressing Enter submits
- Tighten Zod schema from `max(40)` to `max(30)` with regex to align boundary validation with frontend rules
- Add 9 unit tests for `validateNickname` covering valid names, accented chars, URL-problematic chars, control chars, and length limits

Closes #25

## Test plan

- [x] `npm run lint` passes
- [x] `npm run check` passes
- [x] `npm run test:unit` — 48 tests pass (22 in share-planner including 9 new)
- [x] `npm run build` succeeds
- [ ] Manual: type invalid chars (e.g. `foo#bar`) → realtime error shown
- [ ] Manual: type 30 chars → counter shows 0 in coral, input blocked at limit
- [ ] Manual: press Enter in any field → form submits
- [ ] Manual: empty nickname → no error, form submits normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)