### PR TITLE
chore(ci): restrict push trigger to main to prevent duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Restricts the `push` trigger in CI to the `main` branch only
- Feature branches now trigger CI exclusively via `pull_request` events, eliminating duplicate runs when a commit is pushed to an open PR
- Also prevents unintended CI runs on tag pushes

## Test plan
- [x] `npm run lint && npm run format:check && npm run check && npm run test:unit && npm run build` — all pass
- [ ] Manual: push a commit to an open PR while the quality job is running → confirm old run is cancelled
- [ ] Manual: verify quality job still runs on `main` pushes (post-merge)

## Docs
No docs needed — CI-only change with no product or architecture impact.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)