### PR TITLE
feat(race-discovery): add load-more pagination for race lists

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,10 @@
 - Fragment data is untrusted and must be parsed and validated before use.
 - Share pages are always `noindex`.
 
+## Race Listing Pagination
+
+The race listing pages (`/en/races`, `/es/races`) use client-side "Load more" pagination. All race data is passed at build time; the Preact island slices the filtered list into batches of 12 and reveals more on button click. Changing any filter resets pagination to the first batch.
+
 ## Repository Shape
 
 - `src/pages/`, `src/layouts/`

--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -6,12 +6,13 @@ import {
   formatRaceDate,
   getTodayInTimeZone,
 } from "../../lib/format";
-import type { Locale } from "../../lib/config";
+import { DISCOVERY_PAGE_SIZE, type Locale } from "../../lib/config";
 import type { RaceSummary } from "../../lib/races/catalog";
 import {
   filterDiscoveryCards,
   getDiscoveryCards,
   getDiscoveryCountryOptions,
+  paginateDiscoveryCards,
 } from "./race-discovery.logic";
 
 type Props = {
@@ -29,6 +30,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
   const [query, setQuery] = useState("");
   const [country, setCountry] = useState("");
   const [year, setYear] = useState("");
+  const [visibleCount, setVisibleCount] = useState(DISCOVERY_PAGE_SIZE);
 
   const cards = useMemo(
     () => getDiscoveryCards(locale, races),
@@ -37,6 +39,10 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
   const filteredCards = useMemo(
     () => filterDiscoveryCards(cards, { query, country, year }),
     [cards, country, query, year],
+  );
+  const visibleCards = useMemo(
+    () => paginateDiscoveryCards(filteredCards, visibleCount),
+    [filteredCards, visibleCount],
   );
   const availableCountries = useMemo(
     () => getDiscoveryCountryOptions(locale, races),
@@ -58,7 +64,10 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           <input
             type="search"
             value={query}
-            onInput={(event) => setQuery(event.currentTarget.value)}
+            onInput={(event) => {
+              setQuery(event.currentTarget.value);
+              setVisibleCount(DISCOVERY_PAGE_SIZE);
+            }}
             placeholder={dictionary.raceSearchPlaceholder}
             class={inputClass}
             style={baseInputStyle}
@@ -79,7 +88,10 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           </span>
           <select
             value={country}
-            onInput={(event) => setCountry(event.currentTarget.value)}
+            onInput={(event) => {
+              setCountry(event.currentTarget.value);
+              setVisibleCount(DISCOVERY_PAGE_SIZE);
+            }}
             class={inputClass}
             style={baseInputStyle}
             onFocus={(e) =>
@@ -104,7 +116,10 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           </span>
           <select
             value={year}
-            onInput={(event) => setYear(event.currentTarget.value)}
+            onInput={(event) => {
+              setYear(event.currentTarget.value);
+              setVisibleCount(DISCOVERY_PAGE_SIZE);
+            }}
             class={inputClass}
             style={baseInputStyle}
             onFocus={(e) =>
@@ -124,7 +139,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
 
       <div>
         {filteredCards.length > 0 ? (
-          filteredCards.map((card) => {
+          visibleCards.map((card) => {
             const isUpcoming =
               card.meta.date >= getTodayInTimeZone(card.meta.timezone);
             return (
@@ -209,6 +224,24 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           </div>
         )}
       </div>
+
+      {visibleCount < filteredCards.length && (
+        <div class="mt-6 flex flex-col items-center gap-2">
+          <span class="font-mono text-xs" style="color: var(--color-muted);">
+            {visibleCards.length} / {filteredCards.length}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              setVisibleCount((prev) => prev + DISCOVERY_PAGE_SIZE)
+            }
+            class="px-4 py-2 font-mono text-sm transition"
+            style="color: var(--color-accent); border: 1px solid var(--color-line-solid);"
+          >
+            {dictionary.loadMore}
+          </button>
+        </div>
+      )}
 
       <div class="mt-6 text-center">
         <a

--- a/src/features/race-discovery/race-discovery.logic.ts
+++ b/src/features/race-discovery/race-discovery.logic.ts
@@ -41,6 +41,11 @@ export const getDiscoveryCountryOptions = (
         left.value.localeCompare(right.value),
     );
 
+export const paginateDiscoveryCards = (
+  cards: DiscoveryCard[],
+  visibleCount: number,
+): DiscoveryCard[] => cards.slice(0, visibleCount);
+
 export const filterDiscoveryCards = (
   cards: DiscoveryCard[],
   filters: DiscoveryFilters,

--- a/src/features/race-discovery/race-discovery.test.ts
+++ b/src/features/race-discovery/race-discovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterDiscoveryCards,
   getDiscoveryCountryOptions,
+  paginateDiscoveryCards,
 } from "./race-discovery.logic";
 
 const cards = [
@@ -78,6 +79,24 @@ describe("race discovery logic", () => {
     });
 
     expect(result).toHaveLength(1);
+  });
+
+  it("paginates to at most visibleCount cards", () => {
+    const manyCards = Array.from({ length: 5 }, (_, i) => ({
+      ...cards[0],
+      raceSlug: `race-${i}`,
+      href: `/en/races/race-${i}/2026`,
+    }));
+
+    expect(paginateDiscoveryCards(manyCards, 3)).toHaveLength(3);
+  });
+
+  it("returns all cards when visibleCount exceeds length", () => {
+    expect(paginateDiscoveryCards(cards, 100)).toHaveLength(1);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(paginateDiscoveryCards([], 10)).toHaveLength(0);
   });
 
   it("returns no cards when query does not match", () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,7 @@ export const REQUIRED_CHECK_NAMES = [
 export const MAP_TILE_URL =
   "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
 export const MAP_ATTRIBUTION = "&copy; OpenStreetMap contributors &copy; CARTO";
+export const DISCOVERY_PAGE_SIZE = 12;
 export const THEME_STORAGE_KEY = "dtv-theme";
 
 export type Locale = (typeof SUPPORTED_LOCALES)[number];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -103,6 +103,7 @@ type Dictionary = {
   notFoundBody: string;
   notFoundGoHome: string;
   notFoundFindRace: string;
+  loadMore: string;
 };
 
 const DICTIONARIES: Record<Locale, Dictionary> = {
@@ -228,6 +229,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
       "The page you\u2019re looking for doesn\u2019t exist or may have moved.",
     notFoundGoHome: "Go to homepage",
     notFoundFindRace: "Find your race",
+    loadMore: "Load more",
   },
   es: {
     about: "Acerca de",
@@ -353,6 +355,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     notFoundBody: "La p\u00e1gina que buscas no existe o puede haberse movido.",
     notFoundGoHome: "Ir al inicio",
     notFoundFindRace: "Encuentra tu carrera",
+    loadMore: "Cargar más",
   },
 };
 


### PR DESCRIPTION
## Summary
- Add client-side "Load more" pagination to the race listing pages (`/en/races`, `/es/races`)
- All race data is still passed at build time; the Preact island slices the filtered list into batches of 12 and reveals more on button click
- Changing any filter (search, country, year) resets pagination to the first batch

Closes #35

## Changes
| File | Change |
|------|--------|
| `src/lib/config.ts` | `DISCOVERY_PAGE_SIZE = 12` constant |
| `src/lib/i18n.ts` | `loadMore` key in both locale dictionaries |
| `src/features/race-discovery/race-discovery.logic.ts` | `paginateDiscoveryCards()` helper |
| `src/features/race-discovery/race-discovery.test.ts` | 3 unit tests for pagination helper |
| `src/features/race-discovery/DiscoveryListIsland.tsx` | `visibleCount` state, pagination wiring, "Load more" button |
| `docs/architecture.md` | Brief note on client-side pagination approach |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run check` passes (0 errors)
- [x] `npm run test:unit` passes (64 tests)
- [x] `npm run build` succeeds
- [ ] Manual: verify `/en/races` and `/es/races` — initial batch shows, "Load more" works, button hides after last batch, filters reset pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)