### PR TITLE
refactor(data): codify localized race content in edition data

### DIFF
--- a/data/es/carrera-triana-los-remedios-10k/2026/localizations.json
+++ b/data/es/carrera-triana-los-remedios-10k/2026/localizations.json
@@ -1,0 +1,20 @@
+{
+  "es": {
+    "meta": {
+      "name": "Carrera Triana - Los Remedios \"Torre Sevilla\" 10K",
+      "city": "Sevilla",
+      "summary": "10K urbano por La Cartuja, Triana y Los Remedios, con regreso junto al rio hasta la zona de Torre Sevilla.",
+      "heroNote": "El recorrido vuelve por varios puntos muy comodos para animar, con buenas opciones alrededor de Plaza de Cuba, Calle Betis y la ribera de Triana."
+    },
+    "pointLabels": {
+      "start": "Salida - Camino de los Descubrimientos",
+      "km-2-5": "Punto 2.5K - Calle Inca Garcilaso",
+      "cheer-triana-entry": "Punto para animar - Ronda de Triana",
+      "km-5": "Punto 5K - Avenida Alfredo Kraus",
+      "km-7-5": "Punto 7.5K - Calle Asuncion",
+      "cheer-plaza-cuba": "Punto para animar - Plaza de Cuba",
+      "cheer-betis": "Punto para animar - Calle Betis",
+      "finish": "Meta - Torre Sevilla"
+    }
+  }
+}

--- a/data/es/carrera-triana-los-remedios-5k/2026/localizations.json
+++ b/data/es/carrera-triana-los-remedios-5k/2026/localizations.json
@@ -1,0 +1,19 @@
+{
+  "es": {
+    "meta": {
+      "name": "Carrera Triana - Los Remedios \"Torre Sevilla\" 5K",
+      "city": "Sevilla",
+      "summary": "5K compacto que comparte la segunda mitad del recorrido Triana - Los Remedios, desde Blas Infante hasta Torre Sevilla.",
+      "heroNote": "Se puede seguir bien desde Plaza de Cuba, Calle Betis y el tramo final junto al rio sin alejarse del corazon del recorrido.",
+      "specialNote": "La hora de salida indicada es orientativa. Esta 5K empieza cuando la carrera de 10K pasa por el punto de 5K, asi que la salida exacta puede variar ligeramente el dia de la prueba."
+    },
+    "pointLabels": {
+      "start": "Salida - Avenida Alfredo Kraus",
+      "cheer-cigarreras": "Punto para animar - Glorieta de las Cigarreras",
+      "km-2-5": "Punto 2.5K - Calle Asuncion",
+      "cheer-betis": "Punto para animar - Calle Betis",
+      "cheer-paseo-o": "Punto para animar - Paseo Nuestra Senora de la O",
+      "finish": "Meta - Torre Sevilla"
+    }
+  }
+}

--- a/docs/data-race-catalog.md
+++ b/docs/data-race-catalog.md
@@ -23,6 +23,10 @@
 - `points.geojson`
 - `source.json`
 
+## Optional Files Per Edition
+
+- `localizations.json` — locale-specific overrides for meta fields and point labels
+
 ## `meta.json` Schema
 
 | Field                | Type                | Required | Notes                                                         |
@@ -57,6 +61,34 @@
 | `label`      | string                       | Display label (e.g. `"10K split"`, `"Cheer point: Plaza Nueva"`)                                   |
 | `kind`       | `"split"` \| `"cheer-point"` | `split` = timing splits shown in planner; `cheer-point` = spectator locations shown on share pages |
 | `distanceKm` | number                       | Distance from start along the route                                                                |
+
+## `localizations.json` Schema
+
+Optional file. Keys are locale codes (e.g. `"es"`). Each locale entry may contain:
+
+| Field         | Type                     | Notes                                                               |
+| ------------- | ------------------------ | ------------------------------------------------------------------- |
+| `meta`        | object (partial)         | Any subset of: `name`, `city`, `summary`, `heroNote`, `specialNote` |
+| `pointLabels` | `Record<string, string>` | Maps point `id` from `points.geojson` to a localized display label  |
+
+Both fields are optional per locale. Point IDs that don't match any feature in `points.geojson` are silently ignored.
+
+Example:
+
+```json
+{
+  "es": {
+    "meta": {
+      "name": "Carrera Ejemplo 10K",
+      "city": "Sevilla"
+    },
+    "pointLabels": {
+      "start": "Salida",
+      "finish": "Meta"
+    }
+  }
+}
+```
 
 ## Timing Rules
 

--- a/src/lib/races/catalog.ts
+++ b/src/lib/races/catalog.ts
@@ -2,10 +2,12 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
+  localizationsSchema,
   metaSchema,
   pointsFeatureCollectionSchema,
   routeFeatureCollectionSchema,
   sourceSchema,
+  type RaceLocalizations,
   type RaceMeta,
   type RacePointsCollection,
   type RaceRouteCollection,
@@ -21,6 +23,7 @@ export type RaceEdition = {
   source: RaceSource;
   route: RaceRouteCollection;
   points: RacePointsCollection;
+  localizations?: RaceLocalizations;
 };
 
 export type RaceSummary = {
@@ -29,12 +32,26 @@ export type RaceSummary = {
   year: string;
   meta: RaceMeta;
   upcoming: boolean;
+  localizations?: RaceLocalizations;
 };
 
 const DATA_DIRECTORY = path.join(process.cwd(), "data");
 
 const readJson = async <T>(filePath: string): Promise<T> =>
   JSON.parse(await readFile(filePath, "utf8")) as T;
+
+const readOptionalJson = async <T>(
+  filePath: string,
+): Promise<T | undefined> => {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as T;
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+};
 
 const getDirectories = async (directory: string): Promise<string[]> => {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -67,6 +84,13 @@ const loadRaceEdition = async (
     await readJson(path.join(editionDirectory, "points.geojson")),
   );
 
+  const rawLocalizations = await readOptionalJson(
+    path.join(editionDirectory, "localizations.json"),
+  );
+  const localizations = rawLocalizations
+    ? localizationsSchema.parse(rawLocalizations)
+    : undefined;
+
   return {
     countryCode,
     raceSlug,
@@ -75,6 +99,7 @@ const loadRaceEdition = async (
     source,
     route,
     points,
+    localizations,
   };
 };
 
@@ -119,6 +144,7 @@ export const getRaceSummaries = async (): Promise<RaceSummary[]> => {
     year: edition.year,
     meta: edition.meta,
     upcoming: edition.meta.date >= getTodayInTimeZone(edition.meta.timezone),
+    localizations: edition.localizations,
   }));
 };
 

--- a/src/lib/races/localized.test.ts
+++ b/src/lib/races/localized.test.ts
@@ -1,8 +1,58 @@
 import { describe, expect, it } from "vitest";
 
-import { localizeRaceSummary } from "./localized";
+import { localizeRaceEdition, localizeRaceSummary } from "./localized";
+import type { RaceEdition, RaceSummary } from "./catalog";
 
-describe("localized race content", () => {
+const baseMeta10k = {
+  name: 'Triana - Los Remedios 10K "Torre Sevilla"',
+  date: "2026-03-15",
+  distanceKm: 10,
+  city: "Seville",
+  startTime: "09:00",
+  timezone: "Europe/Madrid",
+  officialWebsiteUrl:
+    "https://imd.sevilla.org/programas-deportivos/circuito-carreras-sevilla10/calendario-del-circuito/carrera-popular-triana",
+  summary: "Urban 10K across La Cartuja, Triana, and Los Remedios.",
+  heroNote: "A spectator-friendly course.",
+} as const;
+
+const localizations10k = {
+  es: {
+    meta: {
+      name: 'Carrera Triana - Los Remedios "Torre Sevilla" 10K',
+      city: "Sevilla",
+      summary:
+        "10K urbano por La Cartuja, Triana y Los Remedios, con regreso junto al rio hasta la zona de Torre Sevilla.",
+      heroNote:
+        "El recorrido vuelve por varios puntos muy comodos para animar, con buenas opciones alrededor de Plaza de Cuba, Calle Betis y la ribera de Triana.",
+    },
+    pointLabels: {
+      start: "Salida - Camino de los Descubrimientos",
+      finish: "Meta - Torre Sevilla",
+    },
+  },
+};
+
+const localizations5k = {
+  es: {
+    meta: {
+      name: 'Carrera Triana - Los Remedios "Torre Sevilla" 5K',
+      city: "Sevilla",
+      summary:
+        "5K compacto que comparte la segunda mitad del recorrido Triana - Los Remedios, desde Blas Infante hasta Torre Sevilla.",
+      heroNote:
+        "Se puede seguir bien desde Plaza de Cuba, Calle Betis y el tramo final junto al rio sin alejarse del corazon del recorrido.",
+      specialNote:
+        "La hora de salida indicada es orientativa. Esta 5K empieza cuando la carrera de 10K pasa por el punto de 5K, asi que la salida exacta puede variar ligeramente el dia de la prueba.",
+    },
+    pointLabels: {
+      start: "Salida - Avenida Alfredo Kraus",
+      finish: "Meta - Torre Sevilla",
+    },
+  },
+};
+
+describe("localizeRaceSummary", () => {
   it("returns Spanish overrides for the Triana 10K", () => {
     const summary = localizeRaceSummary(
       {
@@ -10,18 +60,8 @@ describe("localized race content", () => {
         raceSlug: "carrera-triana-los-remedios-10k",
         year: "2026",
         upcoming: true,
-        meta: {
-          name: 'Triana - Los Remedios 10K "Torre Sevilla"',
-          date: "2026-03-15",
-          distanceKm: 10,
-          city: "Seville",
-          startTime: "09:00",
-          timezone: "Europe/Madrid",
-          officialWebsiteUrl:
-            "https://imd.sevilla.org/programas-deportivos/circuito-carreras-sevilla10/calendario-del-circuito/carrera-popular-triana",
-          summary: "Urban 10K across La Cartuja, Triana, and Los Remedios.",
-          heroNote: "A spectator-friendly course.",
-        },
+        meta: baseMeta10k,
+        localizations: localizations10k,
       },
       "es",
     );
@@ -56,10 +96,134 @@ describe("localized race content", () => {
           specialNote:
             "The listed start time is approximate. This 5K starts when the 10K race reaches the 5K mark.",
         },
+        localizations: localizations5k,
       },
       "es",
     );
 
     expect(summary.meta.specialNote).toContain("La hora de salida indicada");
+  });
+
+  it("returns base data when no localizations are present", () => {
+    const summary: RaceSummary = {
+      countryCode: "es",
+      raceSlug: "carrera-triana-los-remedios-10k",
+      year: "2026",
+      upcoming: true,
+      meta: baseMeta10k,
+    };
+
+    const result = localizeRaceSummary(summary, "es");
+    expect(result).toBe(summary);
+  });
+
+  it("returns base data when locale is not in localizations", () => {
+    const summary: RaceSummary = {
+      countryCode: "es",
+      raceSlug: "carrera-triana-los-remedios-10k",
+      year: "2026",
+      upcoming: true,
+      meta: baseMeta10k,
+      localizations: localizations10k,
+    };
+
+    const result = localizeRaceSummary(summary, "en");
+    expect(result).toBe(summary);
+  });
+});
+
+describe("localizeRaceEdition", () => {
+  const baseEdition: RaceEdition = {
+    countryCode: "es",
+    raceSlug: "carrera-triana-los-remedios-10k",
+    year: "2026",
+    meta: baseMeta10k,
+    source: {
+      officialSourceName: "Test",
+      officialSourceUrl: "https://example.com",
+      routeSourceType: "manual-trace",
+      notes: "Test notes",
+    },
+    route: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [-6.0, 37.38],
+              [-6.01, 37.39],
+            ],
+          },
+        },
+      ],
+    },
+    points: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            id: "start",
+            label: "Start",
+            kind: "split",
+            distanceKm: 0,
+          },
+          geometry: { type: "Point", coordinates: [-6.0, 37.38] },
+        },
+        {
+          type: "Feature",
+          properties: {
+            id: "finish",
+            label: "Finish",
+            kind: "split",
+            distanceKm: 10,
+          },
+          geometry: { type: "Point", coordinates: [-6.01, 37.39] },
+        },
+      ],
+    },
+    localizations: localizations10k,
+  };
+
+  it("localizes meta and point labels for Spanish locale", () => {
+    const result = localizeRaceEdition(baseEdition, "es");
+
+    expect(result.meta.name).toBe(
+      'Carrera Triana - Los Remedios "Torre Sevilla" 10K',
+    );
+    expect(result.meta.city).toBe("Sevilla");
+    expect(result.points.features[0].properties.label).toBe(
+      "Salida - Camino de los Descubrimientos",
+    );
+    expect(result.points.features[1].properties.label).toBe(
+      "Meta - Torre Sevilla",
+    );
+  });
+
+  it("returns base edition when no localizations are present", () => {
+    const editionWithoutLocalizations = {
+      ...baseEdition,
+      localizations: undefined,
+    };
+    const result = localizeRaceEdition(editionWithoutLocalizations, "es");
+    expect(result).toBe(editionWithoutLocalizations);
+  });
+
+  it("keeps base label when point ID has no localized label", () => {
+    const editionWithPartialLabels: RaceEdition = {
+      ...baseEdition,
+      localizations: {
+        es: {
+          pointLabels: { start: "Salida" },
+        },
+      },
+    };
+
+    const result = localizeRaceEdition(editionWithPartialLabels, "es");
+    expect(result.points.features[0].properties.label).toBe("Salida");
+    expect(result.points.features[1].properties.label).toBe("Finish");
   });
 });

--- a/src/lib/races/localized.ts
+++ b/src/lib/races/localized.ts
@@ -1,68 +1,11 @@
 import type { Locale } from "../config";
-import type { RaceMeta, RacePointsCollection } from "./schemas";
+import type { RaceLocalizations, RacePointsCollection } from "./schemas";
 import type { RaceEdition, RaceSummary } from "./catalog";
 
-type LocalizedEditionOverride = {
-  meta?: Partial<RaceMeta>;
-  pointLabels?: Record<string, string>;
-};
-
-const LOCALIZED_EDITIONS: Record<
-  string,
-  Partial<Record<Locale, LocalizedEditionOverride>>
-> = {
-  "carrera-triana-los-remedios-10k/2026": {
-    es: {
-      meta: {
-        name: 'Carrera Triana - Los Remedios "Torre Sevilla" 10K',
-        city: "Sevilla",
-        summary:
-          "10K urbano por La Cartuja, Triana y Los Remedios, con regreso junto al rio hasta la zona de Torre Sevilla.",
-        heroNote:
-          "El recorrido vuelve por varios puntos muy comodos para animar, con buenas opciones alrededor de Plaza de Cuba, Calle Betis y la ribera de Triana.",
-      },
-      pointLabels: {
-        start: "Salida - Camino de los Descubrimientos",
-        "km-2-5": "Punto 2.5K - Calle Inca Garcilaso",
-        "cheer-triana-entry": "Punto para animar - Ronda de Triana",
-        "km-5": "Punto 5K - Avenida Alfredo Kraus",
-        "km-7-5": "Punto 7.5K - Calle Asuncion",
-        "cheer-plaza-cuba": "Punto para animar - Plaza de Cuba",
-        "cheer-betis": "Punto para animar - Calle Betis",
-        finish: "Meta - Torre Sevilla",
-      },
-    },
-  },
-  "carrera-triana-los-remedios-5k/2026": {
-    es: {
-      meta: {
-        name: 'Carrera Triana - Los Remedios "Torre Sevilla" 5K',
-        city: "Sevilla",
-        summary:
-          "5K compacto que comparte la segunda mitad del recorrido Triana - Los Remedios, desde Blas Infante hasta Torre Sevilla.",
-        heroNote:
-          "Se puede seguir bien desde Plaza de Cuba, Calle Betis y el tramo final junto al rio sin alejarse del corazon del recorrido.",
-        specialNote:
-          "La hora de salida indicada es orientativa. Esta 5K empieza cuando la carrera de 10K pasa por el punto de 5K, asi que la salida exacta puede variar ligeramente el dia de la prueba.",
-      },
-      pointLabels: {
-        start: "Salida - Avenida Alfredo Kraus",
-        "cheer-cigarreras": "Punto para animar - Glorieta de las Cigarreras",
-        "km-2-5": "Punto 2.5K - Calle Asuncion",
-        "cheer-betis": "Punto para animar - Calle Betis",
-        "cheer-paseo-o": "Punto para animar - Paseo Nuestra Senora de la O",
-        finish: "Meta - Torre Sevilla",
-      },
-    },
-  },
-};
-
 const getEditionOverride = (
-  raceSlug: string,
-  year: string,
+  localizations: RaceLocalizations | undefined,
   locale: Locale,
-): LocalizedEditionOverride | undefined =>
-  LOCALIZED_EDITIONS[`${raceSlug}/${year}`]?.[locale];
+) => localizations?.[locale];
 
 const localizePoints = (
   points: RacePointsCollection,
@@ -88,7 +31,7 @@ export const localizeRaceEdition = (
   edition: RaceEdition,
   locale: Locale,
 ): RaceEdition => {
-  const override = getEditionOverride(edition.raceSlug, edition.year, locale);
+  const override = getEditionOverride(edition.localizations, locale);
 
   if (!override) {
     return edition;
@@ -108,7 +51,7 @@ export const localizeRaceSummary = (
   summary: RaceSummary,
   locale: Locale,
 ): RaceSummary => {
-  const override = getEditionOverride(summary.raceSlug, summary.year, locale);
+  const override = getEditionOverride(summary.localizations, locale);
 
   if (!override?.meta) {
     return summary;

--- a/src/lib/races/schemas.ts
+++ b/src/lib/races/schemas.ts
@@ -62,6 +62,24 @@ export const pointsFeatureCollectionSchema = z.object({
     .min(1),
 });
 
+const localizableMetaSchema = metaSchema
+  .pick({
+    name: true,
+    city: true,
+    summary: true,
+    heroNote: true,
+    specialNote: true,
+  })
+  .partial();
+
+const localeLocalizationSchema = z.object({
+  meta: localizableMetaSchema.optional(),
+  pointLabels: z.record(z.string().min(1), z.string().min(1)).optional(),
+});
+
+export const localizationsSchema = z.record(localeLocalizationSchema);
+export type RaceLocalizations = z.infer<typeof localizationsSchema>;
+
 export type RaceMeta = z.infer<typeof metaSchema>;
 export type RaceSource = z.infer<typeof sourceSchema>;
 export type RaceRouteFeature = z.infer<typeof routeFeatureSchema>;


### PR DESCRIPTION
## Summary

Closes #53

- Move per-race localized content from a hardcoded `LOCALIZED_EDITIONS` TypeScript map into optional `localizations.json` files co-located with each race edition's data directory
- Add `localizationsSchema` and `RaceLocalizations` type to `schemas.ts`, derived from the existing `metaSchema`
- Update `catalog.ts` to load optional `localizations.json` (with graceful ENOENT handling) and pass it through `RaceEdition` and `RaceSummary`
- Rewrite `localized.ts` to read from `edition.localizations` instead of the removed hardcoded map
- Expand test coverage: 7 tests covering Spanish overrides, missing localizations, missing locale, point label merging, and partial labels

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 69/69 passed
- [x] `npm run build` — 24 pages generated
- [x] `npm run test:e2e` — 47/47 passed

Docs updated: `docs/data-race-catalog.md` documents `localizations.json` as optional file with schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)