### PR TITLE
refactor(routes): centralize hardcoded route paths (#47)

### DIFF
--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -7,6 +7,7 @@ import {
   getTodayInTimeZone,
 } from "../../lib/format";
 import { DISCOVERY_PAGE_SIZE, type Locale } from "../../lib/config";
+import { buildContributePath } from "../../lib/routes";
 import type { RaceSummary } from "../../lib/races/catalog";
 import {
   filterDiscoveryCards,
@@ -215,7 +216,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           >
             {dictionary.noMatch}
             <a
-              href={`/${locale}/contribute`}
+              href={buildContributePath(locale)}
               class="mt-2 block text-sm transition"
               style="color: var(--color-accent);"
             >
@@ -245,7 +246,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
 
       <div class="mt-6 text-center">
         <a
-          href={`/${locale}/contribute`}
+          href={buildContributePath(locale)}
           class="font-mono text-sm transition"
           style="color: var(--color-muted);"
           onMouseOver={(e) => {

--- a/src/features/race-discovery/race-discovery.logic.ts
+++ b/src/features/race-discovery/race-discovery.logic.ts
@@ -1,5 +1,6 @@
 import type { Locale } from "../../lib/config";
 import { formatCountryName } from "../../lib/format";
+import { buildRacePath } from "../../lib/routes";
 import type { RaceSummary } from "../../lib/races/catalog";
 
 export type DiscoveryFilters = {
@@ -23,7 +24,7 @@ export const getDiscoveryCards = (
 ): DiscoveryCard[] =>
   races.map((race) => ({
     ...race,
-    href: `/${locale}/races/${race.raceSlug}/${race.year}`,
+    href: buildRacePath(locale, race.raceSlug, race.year),
   }));
 
 export const getDiscoveryCountryOptions = (

--- a/src/features/share-planner/share-planner.logic.ts
+++ b/src/features/share-planner/share-planner.logic.ts
@@ -1,4 +1,4 @@
-import { buildSharePath } from "../../lib/format";
+import { buildSharePath } from "../../lib/routes";
 import {
   parseFinishTimeToMinutes,
   parsePaceToMinutesPerKm,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ import {
   type Locale,
 } from "../lib/config";
 import { getDictionary } from "../lib/i18n";
+import { buildAboutPath, buildHomePath, buildRacesPath } from "../lib/routes";
 import { buildSeo, type SeoInput } from "../lib/seo";
 
 type Props = SeoInput & {
@@ -36,11 +37,11 @@ const seo = buildSeo({
 });
 const navLinks = [
   {
-    href: `/${locale}/races`,
+    href: buildRacesPath(locale),
     label: dictionary.raceDiscovery,
   },
   {
-    href: `/${locale}/about`,
+    href: buildAboutPath(locale),
     label: dictionary.about,
   },
 ];
@@ -118,7 +119,7 @@ const mobileNavId = "site-mobile-nav";
         class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:gap-6 sm:px-8"
       >
         <a
-          href={`/${locale}`}
+          href={buildHomePath(locale)}
           class="flex min-w-0 items-center gap-2.5 sm:gap-3"
         >
           <img

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildRacePath,
-  buildSharePath,
   formatCountryName,
   formatDistance,
   formatRaceDate,
   getTodayInTimeZone,
-  switchLocalePath,
 } from "./format";
 
 describe("format helpers", () => {
@@ -41,27 +38,5 @@ describe("format helpers", () => {
     expect(getTodayInTimeZone("America/New_York", referenceDate)).toBe(
       "2026-03-15",
     );
-  });
-
-  it("builds race paths with and without a year", () => {
-    expect(buildRacePath("en", "carrera-triana-los-remedios-10k", "2026")).toBe(
-      "/en/races/carrera-triana-los-remedios-10k/2026",
-    );
-    expect(buildRacePath("es", "carrera-triana-los-remedios-10k")).toBe(
-      "/es/races/carrera-triana-los-remedios-10k",
-    );
-  });
-
-  it("builds share paths", () => {
-    expect(
-      buildSharePath("en", "carrera-triana-los-remedios-10k", "2026"),
-    ).toBe("/en/share/carrera-triana-los-remedios-10k/2026");
-  });
-
-  it("switches the leading locale segment in a path", () => {
-    expect(
-      switchLocalePath("/en/races/carrera-triana-los-remedios-10k", "es"),
-    ).toBe("/es/races/carrera-triana-los-remedios-10k");
-    expect(switchLocalePath("/es", "en")).toBe("/en");
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,5 +1,10 @@
 import type { Locale } from "./config";
 
+/**
+ * @deprecated Import from "./routes" instead.
+ */
+export { buildRacePath, buildSharePath, switchLocalePath } from "./routes";
+
 const DATE_FORMATTERS: Record<Locale, Intl.DateTimeFormat> = {
   en: new Intl.DateTimeFormat("en-GB", {
     day: "numeric",
@@ -66,21 +71,3 @@ export const getTodayInTimeZone = (
 
   return `${year}-${month}-${day}`;
 };
-
-export const buildRacePath = (
-  locale: Locale,
-  raceSlug: string,
-  year?: string,
-): string =>
-  year
-    ? `/${locale}/races/${raceSlug}/${year}`
-    : `/${locale}/races/${raceSlug}`;
-
-export const buildSharePath = (
-  locale: Locale,
-  raceSlug: string,
-  year: string,
-): string => `/${locale}/share/${raceSlug}/${year}`;
-
-export const switchLocalePath = (pathname: string, locale: Locale): string =>
-  pathname.replace(/^\/(en|es)/, `/${locale}`);

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAboutPath,
+  buildContributePath,
+  buildHomePath,
+  buildPrivacyPath,
+  buildRacePath,
+  buildRacesPath,
+  buildSharePath,
+  EDITION_PATH_PATTERN,
+  switchLocalePath,
+} from "./routes";
+
+describe("route builders", () => {
+  it("builds home paths", () => {
+    expect(buildHomePath("en")).toBe("/en");
+    expect(buildHomePath("es")).toBe("/es");
+  });
+
+  it("builds races listing paths", () => {
+    expect(buildRacesPath("en")).toBe("/en/races");
+    expect(buildRacesPath("es")).toBe("/es/races");
+  });
+
+  it("builds race paths with and without a year", () => {
+    expect(buildRacePath("en", "carrera-triana-los-remedios-10k", "2026")).toBe(
+      "/en/races/carrera-triana-los-remedios-10k/2026",
+    );
+    expect(buildRacePath("es", "carrera-triana-los-remedios-10k")).toBe(
+      "/es/races/carrera-triana-los-remedios-10k",
+    );
+  });
+
+  it("builds share paths", () => {
+    expect(
+      buildSharePath("en", "carrera-triana-los-remedios-10k", "2026"),
+    ).toBe("/en/share/carrera-triana-los-remedios-10k/2026");
+  });
+
+  it("builds about paths", () => {
+    expect(buildAboutPath("en")).toBe("/en/about");
+    expect(buildAboutPath("es")).toBe("/es/about");
+  });
+
+  it("builds privacy paths", () => {
+    expect(buildPrivacyPath("en")).toBe("/en/privacy");
+    expect(buildPrivacyPath("es")).toBe("/es/privacy");
+  });
+
+  it("builds contribute paths", () => {
+    expect(buildContributePath("en")).toBe("/en/contribute");
+    expect(buildContributePath("es")).toBe("/es/contribute");
+  });
+
+  it("switches the leading locale segment in a path", () => {
+    expect(
+      switchLocalePath("/en/races/carrera-triana-los-remedios-10k", "es"),
+    ).toBe("/es/races/carrera-triana-los-remedios-10k");
+    expect(switchLocalePath("/es", "en")).toBe("/en");
+  });
+});
+
+describe("EDITION_PATH_PATTERN", () => {
+  it("matches race edition paths", () => {
+    const match = "/en/races/some-race/2026".match(EDITION_PATH_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("en");
+    expect(match![2]).toBe("some-race");
+    expect(match![3]).toBe("2026");
+  });
+
+  it("matches share edition paths", () => {
+    const match = "/es/share/some-race/2026".match(EDITION_PATH_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("es");
+    expect(match![2]).toBe("some-race");
+    expect(match![3]).toBe("2026");
+  });
+
+  it("does not match non-edition paths", () => {
+    expect("/en/about".match(EDITION_PATH_PATTERN)).toBeNull();
+    expect("/en/races".match(EDITION_PATH_PATTERN)).toBeNull();
+    expect("/en/races/some-race".match(EDITION_PATH_PATTERN)).toBeNull();
+  });
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,46 @@
+import type { Locale } from "./config";
+
+export const ROUTE_SEGMENTS = {
+  races: "races",
+  share: "share",
+  about: "about",
+  privacy: "privacy",
+  contribute: "contribute",
+  og: "og",
+} as const;
+
+export const buildHomePath = (locale: Locale): string => `/${locale}`;
+
+export const buildRacesPath = (locale: Locale): string =>
+  `/${locale}/${ROUTE_SEGMENTS.races}`;
+
+export const buildRacePath = (
+  locale: Locale,
+  raceSlug: string,
+  year?: string,
+): string =>
+  year
+    ? `/${locale}/${ROUTE_SEGMENTS.races}/${raceSlug}/${year}`
+    : `/${locale}/${ROUTE_SEGMENTS.races}/${raceSlug}`;
+
+export const buildSharePath = (
+  locale: Locale,
+  raceSlug: string,
+  year: string,
+): string => `/${locale}/${ROUTE_SEGMENTS.share}/${raceSlug}/${year}`;
+
+export const buildAboutPath = (locale: Locale): string =>
+  `/${locale}/${ROUTE_SEGMENTS.about}`;
+
+export const buildPrivacyPath = (locale: Locale): string =>
+  `/${locale}/${ROUTE_SEGMENTS.privacy}`;
+
+export const buildContributePath = (locale: Locale): string =>
+  `/${locale}/${ROUTE_SEGMENTS.contribute}`;
+
+export const switchLocalePath = (pathname: string, locale: Locale): string =>
+  pathname.replace(/^\/(en|es)/, `/${locale}`);
+
+export const EDITION_PATH_PATTERN = new RegExp(
+  `^\\/(en|es)\\/(?:${ROUTE_SEGMENTS.races}|${ROUTE_SEGMENTS.share})\\/([^/]+)\\/([^/]+)$`,
+);

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -7,6 +7,7 @@ import {
   SITE_NAME,
   type Locale,
 } from "./config";
+import { EDITION_PATH_PATTERN, ROUTE_SEGMENTS } from "./routes";
 
 export type SeoImage = {
   url: string;
@@ -68,13 +69,14 @@ export const buildAlternates = (locale: Locale, pathname: string) => [
 ];
 
 export const buildDefaultSeoImagePath = (locale: Locale): string =>
-  `/og/${locale}/default.png`;
+  `/${ROUTE_SEGMENTS.og}/${locale}/default.png`;
 
 export const buildEditionSeoImagePath = (
   locale: Locale,
   raceSlug: string,
   year: string,
-): string => `/og/${locale}/races/${raceSlug}/${year}.png`;
+): string =>
+  `/${ROUTE_SEGMENTS.og}/${locale}/${ROUTE_SEGMENTS.races}/${raceSlug}/${year}.png`;
 
 export const buildEditionSeoImageAlt = (
   raceName: string,
@@ -85,9 +87,7 @@ const buildDefaultSeoImagePathForPathname = (
   locale: Locale,
   pathname: string,
 ): string => {
-  const editionPathMatch = pathname.match(
-    /^\/(en|es)\/(?:races|share)\/([^/]+)\/([^/]+)$/,
-  );
+  const editionPathMatch = pathname.match(EDITION_PATH_PATTERN);
 
   if (!editionPathMatch) {
     return buildDefaultSeoImagePath(locale);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,6 +6,7 @@ import {
   SUPPORTED_LOCALES,
 } from "../lib/config";
 import { getDictionary } from "../lib/i18n";
+import { buildHomePath, buildRacesPath, ROUTE_SEGMENTS } from "../lib/routes";
 
 const locale = DEFAULT_LOCALE;
 const dictionary = getDictionary(locale);
@@ -64,7 +65,7 @@ const notFoundKeys = {
     </p>
     <div class="mt-8 flex flex-wrap justify-center gap-4">
       <a
-        href={`/${locale}`}
+        href={buildHomePath(locale)}
         data-i18n="notFoundGoHome"
         data-i18n-href="home"
         class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
@@ -75,7 +76,7 @@ const notFoundKeys = {
         {dictionary.notFoundGoHome}
       </a>
       <a
-        href={`/${locale}/races`}
+        href={buildRacesPath(locale)}
         data-i18n="notFoundFindRace"
         data-i18n-href="races"
         class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
@@ -133,6 +134,7 @@ const notFoundKeys = {
       defaultLocale: DEFAULT_LOCALE,
       supportedLocales: SUPPORTED_LOCALES,
       storageKey: LOCALE_STORAGE_KEY,
+      racesSegment: ROUTE_SEGMENTS.races,
     }}
   >
     (function () {
@@ -190,7 +192,7 @@ const notFoundKeys = {
             if (type === "home") {
               el.setAttribute("href", "/" + detected);
             } else if (type === "races") {
-              el.setAttribute("href", "/" + detected + "/races");
+              el.setAttribute("href", "/" + detected + "/" + racesSegment);
             }
           });
 

--- a/src/pages/[locale]/about.astro
+++ b/src/pages/[locale]/about.astro
@@ -7,6 +7,7 @@ import {
   SUPPORTED_LOCALES,
 } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
+import { buildAboutPath } from "../../lib/routes";
 
 export const getStaticPaths = () =>
   SUPPORTED_LOCALES.map((locale) => ({ params: { locale } }));
@@ -19,7 +20,7 @@ const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}/about`}
+  pathname={buildAboutPath(locale)}
   title={`Dondeteveo | ${dictionary.about}`}
   description={dictionary.contactIntro}
   eyebrow={dictionary.about}

--- a/src/pages/[locale]/contribute.astro
+++ b/src/pages/[locale]/contribute.astro
@@ -7,6 +7,7 @@ import {
   SUPPORTED_LOCALES,
 } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
+import { buildContributePath } from "../../lib/routes";
 
 export const getStaticPaths = () =>
   SUPPORTED_LOCALES.map((locale) => ({ params: { locale } }));
@@ -21,7 +22,7 @@ const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}/contribute`}
+  pathname={buildContributePath(locale)}
   title={`Dondeteveo | ${dictionary.contributeTitle}`}
   description={dictionary.contributeIntro}
   eyebrow={dictionary.contributeTitle}

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -4,6 +4,7 @@ import DiscoveryListIsland from "../../features/race-discovery/DiscoveryListIsla
 
 import { type Locale, SUPPORTED_LOCALES } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
+import { buildHomePath, buildRacesPath } from "../../lib/routes";
 import { localizeRaceSummary } from "../../lib/races/localized";
 import { getRaceSummaries } from "../../lib/races/catalog";
 
@@ -19,7 +20,7 @@ const races = (await getRaceSummaries()).map((race) =>
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}`}
+  pathname={buildHomePath(locale)}
   title={`Dondeteveo | ${dictionary.directRaceSearch}`}
   description={dictionary.heroBody}
 >
@@ -51,7 +52,7 @@ const races = (await getRaceSummaries()).map((race) =>
     </p>
     <div class="mt-7">
       <a
-        href={`/${locale}/races`}
+        href={buildRacesPath(locale)}
         class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
         style="background-color: var(--color-coral); color: var(--color-text);"
         onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"

--- a/src/pages/[locale]/privacy.astro
+++ b/src/pages/[locale]/privacy.astro
@@ -3,6 +3,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 
 import { type Locale, SUPPORTED_LOCALES } from "../../lib/config";
 import { getDictionary } from "../../lib/i18n";
+import { buildPrivacyPath } from "../../lib/routes";
 
 export const getStaticPaths = () =>
   SUPPORTED_LOCALES.map((locale) => ({ params: { locale } }));
@@ -13,7 +14,7 @@ const dictionary = getDictionary(locale);
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}/privacy`}
+  pathname={buildPrivacyPath(locale)}
   title={`Dondeteveo | ${dictionary.privacy}`}
   description={dictionary.privacyBody}
   eyebrow={dictionary.privacy}

--- a/src/pages/[locale]/races/[race]/[year].astro
+++ b/src/pages/[locale]/races/[race]/[year].astro
@@ -5,6 +5,7 @@ import SharePlannerIsland from "../../../../features/share-planner/SharePlannerI
 
 import { type Locale, SUPPORTED_LOCALES } from "../../../../lib/config";
 import { formatDistance, formatRaceDate } from "../../../../lib/format";
+import { buildRacePath } from "../../../../lib/routes";
 import { getDictionary } from "../../../../lib/i18n";
 import { getAllRaceEditions } from "../../../../lib/races/catalog";
 import { localizeRaceEdition } from "../../../../lib/races/localized";
@@ -31,7 +32,7 @@ const dictionary = getDictionary(locale);
 const { edition: rawEdition } = Astro.props;
 const edition = localizeRaceEdition(rawEdition, locale);
 const points = getPointSummaries(edition.points);
-const pathname = `/${locale}/races/${edition.raceSlug}/${edition.year}`;
+const pathname = buildRacePath(locale, edition.raceSlug, edition.year);
 const raceInfoFields = [
   {
     label: dictionary.date,

--- a/src/pages/[locale]/races/[race]/index.astro
+++ b/src/pages/[locale]/races/[race]/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "../../../../layouts/BaseLayout.astro";
 
 import { type Locale, SUPPORTED_LOCALES } from "../../../../lib/config";
 import { getDictionary } from "../../../../lib/i18n";
+import { buildRacePath } from "../../../../lib/routes";
 import {
   getAllRaceEditions,
   getDistinctRaces,
@@ -43,12 +44,15 @@ const fallbackEditions = editions.toSorted((left, right) =>
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}/races/${raceSlug}`}
+  pathname={buildRacePath(locale, raceSlug)}
   title={`Dondeteveo | ${raceSlug}`}
   description={dictionary.latestEditionRedirect}
   noindex={true}
 >
-  <script is:inline define:vars={{ editions, locale, raceSlug }}>
+  <script
+    is:inline
+    define:vars={{ editions, raceBasePath: buildRacePath(locale, raceSlug) }}
+  >
     const getTodayInTimeZone = (timeZone) => {
       const parts = new Intl.DateTimeFormat("en-CA", {
         timeZone,
@@ -74,9 +78,7 @@ const fallbackEditions = editions.toSorted((left, right) =>
       )[0];
 
     if (targetEdition) {
-      window.location.replace(
-        `/${locale}/races/${raceSlug}/${targetEdition.year}`,
-      );
+      window.location.replace(raceBasePath + "/" + targetEdition.year);
     }
   </script>
   <div
@@ -90,7 +92,7 @@ const fallbackEditions = editions.toSorted((left, right) =>
       {
         fallbackEditions.map((edition) => (
           <a
-            href={`/${locale}/races/${raceSlug}/${edition.year}`}
+            href={buildRacePath(locale, raceSlug, edition.year)}
             class="inline-flex rounded-lg border px-4 py-2 text-sm font-bold transition"
             style="border-color: rgba(242,100,25,0.3); color: var(--color-orange);"
             onmouseover="this.style.borderColor='var(--color-orange)'; this.style.backgroundColor='var(--color-amber)';"

--- a/src/pages/[locale]/races/index.astro
+++ b/src/pages/[locale]/races/index.astro
@@ -4,6 +4,7 @@ import DiscoveryListIsland from "../../../features/race-discovery/DiscoveryListI
 
 import { type Locale, SUPPORTED_LOCALES } from "../../../lib/config";
 import { getDictionary } from "../../../lib/i18n";
+import { buildRacesPath } from "../../../lib/routes";
 import { getRaceSummaries } from "../../../lib/races/catalog";
 import { localizeRaceSummary } from "../../../lib/races/localized";
 
@@ -19,7 +20,7 @@ const races = (await getRaceSummaries()).map((race) =>
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}/races`}
+  pathname={buildRacesPath(locale)}
   title={`Dondeteveo | ${dictionary.discoverTitle}`}
   description={dictionary.discoverIntro}
   eyebrow={dictionary.discoverTitle}

--- a/src/pages/[locale]/share/[race]/[year].astro
+++ b/src/pages/[locale]/share/[race]/[year].astro
@@ -4,6 +4,7 @@ import ShareExperienceIsland from "../../../../features/share-view/ShareExperien
 
 import { type Locale, SUPPORTED_LOCALES } from "../../../../lib/config";
 import { getDictionary } from "../../../../lib/i18n";
+import { buildSharePath } from "../../../../lib/routes";
 import { getAllRaceEditions } from "../../../../lib/races/catalog";
 import { localizeRaceEdition } from "../../../../lib/races/localized";
 
@@ -27,7 +28,7 @@ const locale = Astro.params.locale as Locale;
 const dictionary = getDictionary(locale);
 const { edition: rawEdition } = Astro.props;
 const edition = localizeRaceEdition(rawEdition, locale);
-const pathname = `/${locale}/share/${edition.raceSlug}/${edition.year}`;
+const pathname = buildSharePath(locale, edition.raceSlug, edition.year);
 
 const getSpanishRaceConnector = (raceName: string): string => {
   const normalized = raceName

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import DiscoveryListIsland from "../features/race-discovery/DiscoveryListIsland"
 
 import { LOCALE_STORAGE_KEY, SUPPORTED_LOCALES } from "../lib/config";
 import { getDictionary } from "../lib/i18n";
+import { buildHomePath, buildRacesPath } from "../lib/routes";
 import { localizeRaceSummary } from "../lib/races/localized";
 import { getRaceSummaries } from "../lib/races/catalog";
 
@@ -16,7 +17,7 @@ const races = (await getRaceSummaries()).map((race) =>
 
 <BaseLayout
   locale={locale}
-  pathname={`/${locale}`}
+  pathname={buildHomePath(locale)}
   title={`Dondeteveo | ${dictionary.directRaceSearch}`}
   description={dictionary.heroBody}
 >
@@ -48,7 +49,7 @@ const races = (await getRaceSummaries()).map((race) =>
     </p>
     <div class="mt-7">
       <a
-        href={`/${locale}/races`}
+        href={buildRacesPath(locale)}
         class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
         style="background-color: var(--color-coral); color: var(--color-text);"
         onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"


### PR DESCRIPTION
## Summary
- Creates `src/lib/routes.ts` with `ROUTE_SEGMENTS` constant, 8 path builder functions, and `EDITION_PATH_PATTERN` regex as a single source of truth for all route paths
- Updates ~17 consumer files (Astro pages, feature logic, layout, SEO) to import from the new routes module instead of using inline string literals
- Moves path builder tests from `format.test.ts` to new `routes.test.ts` (11 tests); keeps deprecated re-exports in `format.ts` for backward compatibility

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:unit` — 77 tests pass (10 suites)
- [x] `npm run build` — 24 pages built successfully
- [ ] Verify no docs update needed (pure refactor, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)