### PR TITLE
refactor(ui): replace inline CSS with Tailwind utilities (#38)

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -16,10 +16,7 @@ export function Tooltip({
   return (
     <div class={`relative inline-block${className ? ` ${className}` : ""}`}>
       {visible && (
-        <div
-          class="absolute right-0 bottom-full mb-2 font-mono text-[10px] whitespace-nowrap"
-          style="background-color: var(--color-text); color: var(--color-bg); padding: 0.25rem 0.5rem;"
-        >
+        <div class="bg-text text-bg absolute right-0 bottom-full mb-2 px-2 py-1 font-mono text-[10px] whitespace-nowrap">
           {text}
           <div
             class="absolute right-2"

--- a/src/components/astro/LanguageSwitch.astro
+++ b/src/components/astro/LanguageSwitch.astro
@@ -20,22 +20,12 @@ const alternatePath = switchLocalePath(pathname, alternateLocale);
 <a
   href={alternatePath}
   data-preserve-hash-link
-  class="lang-switch inline-flex items-center gap-1.5 border px-2.5 py-1 text-[9px] font-bold tracking-[0.22em] uppercase transition sm:px-3 sm:py-1.5 sm:text-[10px] sm:tracking-[0.24em]"
-  style="border-color: var(--color-line); background-color: var(--color-accent-dim); color: var(--color-accent);"
+  class="border-line bg-accent-dim text-accent hover:border-accent hover:bg-line inline-flex items-center gap-1.5 border px-2.5 py-1 text-[9px] font-bold tracking-[0.22em] uppercase transition sm:px-3 sm:py-1.5 sm:text-[10px] sm:tracking-[0.24em]"
 >
   <span>{LOCALE_LABELS[currentLocale].slice(0, 2)}</span>
-  <span style="color: var(--color-muted);">/</span>
-  <span style="color: var(--color-muted);"
-    >{LOCALE_LABELS[alternateLocale].slice(0, 2)}</span
-  >
+  <span class="text-muted">/</span>
+  <span class="text-muted">{LOCALE_LABELS[alternateLocale].slice(0, 2)}</span>
 </a>
-
-<style>
-  .lang-switch:hover {
-    background-color: var(--color-line) !important;
-    border-color: var(--color-accent) !important;
-  }
-</style>
 
 <script is:inline define:vars={{ storageKey: LOCALE_STORAGE_KEY }}>
   document.querySelectorAll("[data-preserve-hash-link]").forEach((element) => {

--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -22,9 +22,7 @@ type Props = {
 };
 
 const inputClass =
-  "w-full border-b bg-transparent px-0 py-2 font-mono text-sm outline-none transition";
-const baseInputStyle =
-  "border-color: var(--color-line-solid); color: var(--color-text);";
+  "w-full border-b border-line-solid bg-transparent px-0 py-2 font-mono text-sm text-text outline-none transition focus:border-accent";
 
 export default function DiscoveryListIsland({ locale, races }: Props) {
   const dictionary = getDictionary(locale);
@@ -56,10 +54,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
     <div class="space-y-6">
       <div class="grid gap-6 md:grid-cols-[2fr_1fr_1fr]">
         <label class="flex flex-col gap-1.5">
-          <span
-            class="font-mono text-[10px] tracking-[0.26em] uppercase"
-            style="color: var(--color-muted);"
-          >
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.search}
           </span>
           <input
@@ -71,20 +66,10 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             }}
             placeholder={dictionary.raceSearchPlaceholder}
             class={inputClass}
-            style={baseInputStyle}
-            onFocus={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-accent)")
-            }
-            onBlur={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-            }
           />
         </label>
         <label class="flex flex-col gap-1.5">
-          <span
-            class="font-mono text-[10px] tracking-[0.26em] uppercase"
-            style="color: var(--color-muted);"
-          >
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.country}
           </span>
           <select
@@ -94,13 +79,6 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
               setVisibleCount(DISCOVERY_PAGE_SIZE);
             }}
             class={inputClass}
-            style={baseInputStyle}
-            onFocus={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-accent)")
-            }
-            onBlur={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-            }
           >
             <option value="">{dictionary.allFilter}</option>
             {availableCountries.map((country) => (
@@ -109,10 +87,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           </select>
         </label>
         <label class="flex flex-col gap-1.5">
-          <span
-            class="font-mono text-[10px] tracking-[0.26em] uppercase"
-            style="color: var(--color-muted);"
-          >
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.date}
           </span>
           <select
@@ -122,13 +97,6 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
               setVisibleCount(DISCOVERY_PAGE_SIZE);
             }}
             class={inputClass}
-            style={baseInputStyle}
-            onFocus={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-accent)")
-            }
-            onBlur={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-            }
           >
             <option value="">{dictionary.allFilter}</option>
             {availableYears.map((yearOption) => (
@@ -146,63 +114,37 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             return (
               <a
                 href={card.href}
-                class="race-row group flex items-center justify-between gap-4 py-4 pr-2 transition-colors"
-                style="border-bottom: 1px solid var(--color-line);"
-                onMouseOver={(e) => {
-                  (e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-                    "var(--color-surface)";
-                }}
-                onMouseOut={(e) => {
-                  (e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-                    "";
-                }}
+                class="race-row group border-line hover:bg-surface flex items-center justify-between gap-4 border-b py-4 pr-2 transition-colors"
               >
                 <div class="flex min-w-0 items-center gap-4">
                   <div
-                    class="w-0.5 shrink-0 self-stretch"
-                    style={`background-color: ${isUpcoming ? "var(--color-accent)" : "var(--color-line-solid)"};`}
+                    class={`w-0.5 shrink-0 self-stretch ${isUpcoming ? "bg-accent" : "bg-line-solid"}`}
                   ></div>
                   <div class="min-w-0">
-                    <h2
-                      class="font-display text-xl leading-tight font-bold uppercase"
-                      style="color: var(--color-text);"
-                    >
+                    <h2 class="font-display text-text text-xl leading-tight font-bold uppercase">
                       {card.meta.name}
                     </h2>
-                    <div
-                      class="mt-0.5 font-mono text-xs"
-                      style="color: var(--color-muted);"
-                    >
+                    <div class="text-muted mt-0.5 font-mono text-xs">
                       {card.meta.city}
                     </div>
                   </div>
                 </div>
                 <div class="flex shrink-0 items-center gap-4 font-mono text-xs">
                   <span
-                    class="px-2 py-0.5 text-[10px] tracking-wider"
-                    style={`background-color: var(--color-surface-raised); color: ${isUpcoming ? "var(--color-accent)" : "var(--color-muted)"};`}
+                    class={`bg-surface-raised px-2 py-0.5 text-[10px] tracking-wider ${isUpcoming ? "text-accent" : "text-muted"}`}
                   >
                     {isUpcoming
                       ? dictionary.upcomingEdition
                       : dictionary.pastEdition}
                   </span>
-                  <span
-                    class="hidden md:inline"
-                    style="color: var(--color-muted);"
-                  >
+                  <span class="text-muted hidden md:inline">
                     {formatRaceDate(card.meta.date, locale)}
                   </span>
-                  <span
-                    class="hidden lg:inline"
-                    style="color: var(--color-muted);"
-                  >
+                  <span class="text-muted hidden lg:inline">
                     {formatDistance(card.meta.distanceKm, locale)}
                   </span>
-                  <span style="color: var(--color-muted);">{card.year}</span>
-                  <span
-                    class="transition-transform group-hover:translate-x-0.5"
-                    style="color: var(--color-accent);"
-                  >
+                  <span class="text-muted">{card.year}</span>
+                  <span class="text-accent transition-transform group-hover:translate-x-0.5">
                     →
                   </span>
                 </div>
@@ -210,15 +152,11 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             );
           })
         ) : (
-          <div
-            class="border border-dashed p-6 font-mono text-sm leading-7"
-            style="border-color: var(--color-line); color: var(--color-muted);"
-          >
+          <div class="border-line text-muted border border-dashed p-6 font-mono text-sm leading-7">
             {dictionary.noMatch}
             <a
               href={buildContributePath(locale)}
-              class="mt-2 block text-sm transition"
-              style="color: var(--color-accent);"
+              class="text-accent mt-2 block text-sm transition"
             >
               {dictionary.cantFindRace} →
             </a>
@@ -228,7 +166,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
 
       {visibleCount < filteredCards.length && (
         <div class="mt-6 flex flex-col items-center gap-2">
-          <span class="font-mono text-xs" style="color: var(--color-muted);">
+          <span class="text-muted font-mono text-xs">
             {visibleCards.length} / {filteredCards.length}
           </span>
           <button
@@ -236,8 +174,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             onClick={() =>
               setVisibleCount((prev) => prev + DISCOVERY_PAGE_SIZE)
             }
-            class="px-4 py-2 font-mono text-sm transition"
-            style="color: var(--color-accent); border: 1px solid var(--color-line-solid);"
+            class="border-line-solid text-accent border px-4 py-2 font-mono text-sm transition"
           >
             {dictionary.loadMore}
           </button>
@@ -247,16 +184,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
       <div class="mt-6 text-center">
         <a
           href={buildContributePath(locale)}
-          class="font-mono text-sm transition"
-          style="color: var(--color-muted);"
-          onMouseOver={(e) => {
-            (e.currentTarget as HTMLAnchorElement).style.color =
-              "var(--color-accent)";
-          }}
-          onMouseOut={(e) => {
-            (e.currentTarget as HTMLAnchorElement).style.color =
-              "var(--color-muted)";
-          }}
+          class="text-muted hover:text-accent font-mono text-sm transition"
         >
           {dictionary.cantFindRace} →
         </a>

--- a/src/features/race-map/RaceMapIsland.tsx
+++ b/src/features/race-map/RaceMapIsland.tsx
@@ -302,16 +302,14 @@ export default function RaceMapIsland({
   return (
     <div
       ref={wrapperRef}
-      class="relative overflow-hidden"
-      style="border: 1px solid var(--color-line); background-color: var(--color-surface);"
+      class="border-line bg-surface relative overflow-hidden border"
     >
       {mode === "spectator" && canFullscreen && (
         <button
           type="button"
           data-map-fullscreen-toggle
           onClick={handleToggleFullscreen}
-          class="absolute top-3 right-3 z-[500] flex h-10 w-10 items-center justify-center"
-          style="background-color: var(--color-surface-raised); color: var(--color-text); border: 1px solid var(--color-line); cursor: pointer;"
+          class="border-line bg-surface-raised text-text absolute top-3 right-3 z-[500] flex h-10 w-10 cursor-pointer items-center justify-center border"
           aria-label={
             isFullscreen
               ? dictionary.exitFullscreenMap
@@ -366,21 +364,16 @@ export default function RaceMapIsland({
         ref={containerRef}
         data-race-map
         data-map-mode={mode}
-        class="w-full overflow-hidden"
-        style={isFullscreen ? "height: 100%;" : "height: 24rem;"}
+        class={`w-full overflow-hidden ${isFullscreen ? "h-full" : "h-96"}`}
       />
       {mode !== "static" && panelState && (
         <div
           data-route-selection-panel
-          class="absolute right-3 bottom-3 left-3 z-[500] max-w-md p-4 sm:left-auto"
-          style="background-color: var(--color-surface-raised); border: 1px solid var(--color-line); box-shadow: var(--shadow-md);"
+          class="border-line bg-surface-raised absolute right-3 bottom-3 left-3 z-[500] max-w-md border p-4 shadow-md sm:left-auto"
         >
           <div class="flex items-start justify-between gap-4">
             <div>
-              <div
-                class="font-mono text-[10px] tracking-[0.24em] uppercase"
-                style="color: var(--color-muted);"
-              >
+              <div class="text-muted font-mono text-[10px] tracking-[0.24em] uppercase">
                 {selectedRoute
                   ? dictionary.selectedRoutePoint
                   : selectedMarker?.kind === "cheer-point"
@@ -389,8 +382,7 @@ export default function RaceMapIsland({
               </div>
               <div
                 data-route-selection-primary
-                class="font-display mt-2 text-2xl font-bold uppercase"
-                style="color: var(--color-text);"
+                class="font-display text-text mt-2 text-2xl font-bold uppercase"
               >
                 {selectedRoute
                   ? formatExactDistance(selectedRoute.distanceKm, locale)
@@ -401,8 +393,7 @@ export default function RaceMapIsland({
               type="button"
               data-route-selection-dismiss
               onClick={handleDismissSelection}
-              class="shrink-0 px-2 py-1 font-mono text-sm uppercase"
-              style="background: none; color: var(--color-muted); border: 1px solid var(--color-line); cursor: pointer;"
+              class="border-line text-muted shrink-0 cursor-pointer border bg-transparent px-2 py-1 font-mono text-sm uppercase"
               aria-label={dictionary.dismissRoutePoint}
             >
               X
@@ -414,18 +405,14 @@ export default function RaceMapIsland({
             </div>
           )}
           {mode === "spectator" && predictedPassingTime && selectedRoute && (
-            <div
-              class="mt-4 font-mono text-sm"
-              style="color: var(--color-text);"
-            >
+            <div class="text-text mt-4 font-mono text-sm">
               <span data-route-selection-time>{predictedPassingTime}</span>
             </div>
           )}
           {selectedMarker?.detail && (
             <div
               data-point-selection-detail
-              class="mt-4 font-mono text-sm leading-6"
-              style="color: var(--color-text);"
+              class="text-text mt-4 font-mono text-sm leading-6"
             >
               {selectedMarker.detail}
             </div>

--- a/src/features/share-planner/SharePlannerIsland.tsx
+++ b/src/features/share-planner/SharePlannerIsland.tsx
@@ -19,9 +19,7 @@ type Props = {
 };
 
 const fieldInputClass =
-  "w-full border-b bg-transparent px-0 py-2 font-mono text-sm outline-none transition";
-const fieldInputStyle =
-  "border-color: var(--color-line-solid); color: var(--color-text);";
+  "w-full border-b border-line-solid bg-transparent px-0 py-2 font-mono text-sm text-text outline-none transition focus:border-accent";
 
 export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
   const dictionary = getDictionary(locale);
@@ -92,28 +90,16 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
   const href = buildShareHref({ locale, raceSlug, year, mode, value, name });
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
-    >
-      <div
-        class="font-mono text-[10px] tracking-[0.3em] uppercase"
-        style="color: var(--color-accent);"
-      >
+    <form onSubmit={handleSubmit} class="card-surface">
+      <div class="text-accent font-mono text-[10px] tracking-[0.3em] uppercase">
         {dictionary.share}
       </div>
-      <p
-        class="mt-2 font-mono text-sm leading-7"
-        style="color: var(--color-muted);"
-      >
+      <p class="text-muted mt-2 font-mono text-sm leading-7">
         {dictionary.shareIntro}
       </p>
       <div class="mt-5 grid gap-4 md:grid-cols-2">
         <label class="flex flex-col gap-1.5">
-          <span
-            class="font-mono text-[10px] tracking-[0.26em] uppercase"
-            style="color: var(--color-muted);"
-          >
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.plannerMode}
           </span>
           <select
@@ -122,23 +108,13 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
               handleModeChange(event.currentTarget.value as ShareMode)
             }
             class={fieldInputClass}
-            style={fieldInputStyle}
-            onFocus={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-accent)")
-            }
-            onBlur={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-            }
           >
             <option value="pace">{dictionary.pace}</option>
             <option value="finish">{dictionary.finishTime}</option>
           </select>
         </label>
         <label class="flex flex-col gap-1.5">
-          <span
-            class="font-mono text-[10px] tracking-[0.26em] uppercase"
-            style="color: var(--color-muted);"
-          >
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {mode === "pace" ? dictionary.pacePerKm : dictionary.finishTime}
           </span>
           <input
@@ -148,31 +124,17 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
             placeholder={getDefaultShareValue(mode)}
             inputMode="numeric"
             class={fieldInputClass}
-            style={fieldInputStyle}
-            onFocus={(e) => {
-              e.currentTarget.style.borderColor = "var(--color-accent)";
-              handleValueFocus(e);
-            }}
-            onBlur={(e) =>
-              (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-            }
+            onFocus={handleValueFocus}
           />
           {error && (
-            <span
-              class="font-mono text-xs"
-              style="color: var(--color-coral-deep);"
-              role="alert"
-            >
+            <span class="text-coral-deep font-mono text-xs" role="alert">
               {error}
             </span>
           )}
         </label>
       </div>
       <label class="mt-4 flex flex-col gap-1.5">
-        <span
-          class="font-mono text-[10px] tracking-[0.26em] uppercase"
-          style="color: var(--color-muted);"
-        >
+        <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
           {dictionary.optionalNickname}
         </span>
         <input
@@ -181,29 +143,17 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
           maxLength={NICKNAME_MAX_LENGTH}
           onInput={handleNameInput}
           class={fieldInputClass}
-          style={fieldInputStyle}
-          onFocus={(e) =>
-            (e.currentTarget.style.borderColor = "var(--color-accent)")
-          }
-          onBlur={(e) =>
-            (e.currentTarget.style.borderColor = "var(--color-line-solid)")
-          }
         />
         <div class="flex items-baseline justify-between gap-2">
           {nameError ? (
-            <span
-              class="font-mono text-xs"
-              style="color: var(--color-coral-deep);"
-              role="alert"
-            >
+            <span class="text-coral-deep font-mono text-xs" role="alert">
               {nameError}
             </span>
           ) : (
             <span />
           )}
           <span
-            class={`shrink-0 font-mono text-[10px]${name.length === 0 ? "invisible" : ""}`}
-            style={`color: var(${name.length >= NICKNAME_MAX_LENGTH ? "--color-coral-deep" : "--color-muted"});`}
+            class={`shrink-0 font-mono text-[10px] ${name.length === 0 ? "invisible" : ""} ${name.length >= NICKNAME_MAX_LENGTH ? "text-coral-deep" : "text-muted"}`}
           >
             {NICKNAME_MAX_LENGTH - name.length}
           </span>
@@ -212,16 +162,7 @@ export default function SharePlannerIsland({ locale, raceSlug, year }: Props) {
       <a
         ref={linkRef}
         href={href}
-        class="mt-6 inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="background-color: var(--color-coral); color: var(--color-text);"
-        onMouseOver={(e) => {
-          (e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-            "var(--color-coral-deep)";
-        }}
-        onMouseOut={(e) => {
-          (e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-            "var(--color-coral)";
-        }}
+        class="bg-coral text-text hover:bg-coral-deep mt-6 inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
       >
         {dictionary.generateShareLink}
       </a>

--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -209,23 +209,14 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
 
   if (!shareState || paceMinutesPerKm === null) {
     return (
-      <div style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;">
-        <div
-          class="font-mono text-[10px] tracking-[0.3em] uppercase"
-          style="color: var(--color-muted);"
-        >
+      <div class="card-surface">
+        <div class="text-muted font-mono text-[10px] tracking-[0.3em] uppercase">
           {dictionary.spectatorReady}
         </div>
-        <h2
-          class="font-display mt-2 text-4xl font-bold uppercase"
-          style="color: var(--color-text);"
-        >
+        <h2 class="font-display text-text mt-2 text-4xl font-bold uppercase">
           {dictionary.sharePageTitle}
         </h2>
-        <p
-          class="mt-3 max-w-2xl font-mono text-base leading-7"
-          style="color: var(--color-muted);"
-        >
+        <p class="text-muted mt-3 max-w-2xl font-mono text-base leading-7">
           {dictionary.invalidShareState}
         </p>
       </div>
@@ -236,22 +227,15 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
     <div class="space-y-8">
       {/* Share URL box */}
       <div>
-        <div
-          class="mb-1 font-mono text-[10px] tracking-[0.3em] uppercase"
-          style="color: var(--color-muted);"
-        >
+        <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
           {dictionary.shareLinkTitle}
         </div>
-        <div
-          class="flex items-center gap-2"
-          style="background-color: var(--color-surface-raised); border: 1px solid var(--color-line); padding: 0.5rem 0.75rem;"
-        >
+        <div class="border-line bg-surface-raised flex items-center gap-2 border px-3 py-2">
           <input
             type="text"
             readOnly
             value={currentHref}
-            class="min-w-0 flex-1 overflow-hidden border-none bg-transparent font-mono text-xs text-ellipsis outline-none"
-            style="color: var(--color-text);"
+            class="text-text min-w-0 flex-1 overflow-hidden border-none bg-transparent font-mono text-xs text-ellipsis outline-none"
           />
           <Tooltip
             text={dictionary.copiedToClipboard}
@@ -261,7 +245,7 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
             <button
               type="button"
               onClick={handleCopy}
-              style="color: var(--color-accent); background: none; border: none; cursor: pointer; padding: 0.25rem;"
+              class="text-accent cursor-pointer border-none bg-transparent p-1"
               aria-label={dictionary.copyLink}
             >
               {copied ? (
@@ -305,7 +289,7 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
               <button
                 type="button"
                 onClick={handleShare}
-                style="color: var(--color-accent); background: none; border: none; cursor: pointer; padding: 0.25rem;"
+                class="text-accent cursor-pointer border-none bg-transparent p-1"
                 aria-label={dictionary.shareLink}
               >
                 {shared ? (
@@ -346,42 +330,26 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
       </div>
 
       {/* Runner header band */}
-      <div style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.25rem 1.5rem;">
-        <h2
-          class="font-display text-4xl font-bold uppercase"
-          style="color: var(--color-text);"
-        >
-          {edition.meta.name}{" "}
-          <span style="color: var(--color-accent);">· {edition.year}</span>
+      <div class="border-line bg-surface border px-6 py-5">
+        <h2 class="font-display text-text text-4xl font-bold uppercase">
+          {edition.meta.name} <span class="text-accent">· {edition.year}</span>
         </h2>
         {shareState.name && (
-          <div
-            class="mt-3 inline-block px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase"
-            style="background-color: var(--color-surface-raised); color: var(--color-accent); border: 1px solid var(--color-line);"
-          >
+          <div class="border-line bg-surface-raised text-accent mt-3 inline-block border px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase">
             {dictionary.runnerLabel}: {shareState.name}
           </div>
         )}
-        <div class="mt-3 font-mono text-sm" style="color: var(--color-muted);">
-          <span style="color: var(--color-text);">{dictionary.startTime}:</span>{" "}
+        <div class="text-muted mt-3 font-mono text-sm">
+          <span class="text-text">{dictionary.startTime}:</span>{" "}
           {edition.meta.startTime}
           <span class="ml-2">({edition.meta.timezone})</span>
         </div>
         {edition.meta.specialNote && (
-          <div
-            class="mt-4"
-            style="background-color: var(--color-surface-warning); border: 1px solid var(--color-warning-line); padding: 1rem 1.25rem;"
-          >
-            <div
-              class="font-mono text-[10px] tracking-[0.28em] uppercase"
-              style="color: var(--color-warning);"
-            >
+          <div class="banner-warning mt-4">
+            <div class="text-warning font-mono text-[10px] tracking-[0.28em] uppercase">
               // {dictionary.importantRaceNote}
             </div>
-            <p
-              class="mt-3 font-mono text-sm leading-6"
-              style="color: var(--color-text);"
-            >
+            <p class="text-text mt-3 font-mono text-sm leading-6">
               {edition.meta.specialNote}
             </p>
           </div>
@@ -390,16 +358,10 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
 
       {/* Timing cards — hero */}
       <div>
-        <div
-          class="mb-1 font-mono text-[10px] tracking-[0.3em] uppercase"
-          style="color: var(--color-muted);"
-        >
+        <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
           {dictionary.predictedTimes}
         </div>
-        <p
-          class="mb-4 font-mono text-xs leading-6"
-          style="color: var(--color-muted);"
-        >
+        <p class="text-muted mb-4 font-mono text-xs leading-6">
           {dictionary.allTimesRaceLocal}
         </p>
         <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -407,58 +369,40 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
             <button
               key={point.id}
               type="button"
-              class="timing-card flex w-full flex-col text-left"
+              class={`timing-card bg-surface flex w-full cursor-pointer flex-col border p-6 text-left ${
+                selectedPointId === point.id ? "border-accent" : "border-line"
+              }`}
               data-predicted-point-card
               data-point-id={point.id}
               data-selected={selectedPointId === point.id ? "true" : "false"}
               aria-pressed={selectedPointId === point.id}
               onClick={() => handleTimingCardSelect(point.id)}
-              style={`background-color: var(--color-surface); border: 1px solid ${
-                selectedPointId === point.id
-                  ? "var(--color-accent)"
-                  : "var(--color-line)"
-              }; padding: 1.5rem; cursor: pointer; width: 100%;`}
             >
               <div class="flex-1">
-                <div
-                  class="font-mono text-[9px] tracking-[0.32em] uppercase"
-                  style="color: var(--color-muted);"
-                >
+                <div class="text-muted font-mono text-[9px] tracking-[0.32em] uppercase">
                   {point.kind === "split"
                     ? dictionary.splitLabel
                     : dictionary.cheerPointLabel}
                 </div>
-                <h4
-                  class="font-display mt-1 text-xl leading-tight font-bold uppercase"
-                  style="color: var(--color-text);"
-                >
+                <h4 class="font-display text-text mt-1 text-xl leading-tight font-bold uppercase">
                   {point.label}
                 </h4>
-                <div
-                  class="mt-1 font-mono text-xs"
-                  style="color: var(--color-muted);"
-                >
+                <div class="text-muted mt-1 font-mono text-xs">
                   {formatDistance(point.distanceKm, locale)}
                 </div>
               </div>
               <div
-                class="mt-4 flex items-baseline gap-2 font-mono leading-none font-medium"
-                style={`font-size: clamp(2.8rem, 8vw, 4rem); color: var(--color-coral); letter-spacing: -0.02em;`}
+                class="text-coral mt-4 flex items-baseline gap-2 font-mono leading-none font-medium tracking-[-0.02em]"
+                style="font-size: clamp(2.8rem, 8vw, 4rem);"
               >
                 {point.predictedTime}
                 {point.dayOffset > 0 && (
-                  <span
-                    class="font-mono text-xs font-normal tracking-wide"
-                    style="color: var(--color-muted);"
-                  >
+                  <span class="text-muted font-mono text-xs font-normal tracking-wide">
                     {formatDayOffset(point.dayOffset)}
                   </span>
                 )}
               </div>
-              <div
-                class="mt-3 font-mono text-xs leading-5"
-                style="color: var(--color-muted);"
-              >
+              <div class="text-muted mt-3 font-mono text-xs leading-5">
                 {formatSafetyMargin(point)}
               </div>
             </button>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -112,9 +112,7 @@ const mobileNavId = "site-mobile-nav";
     </script>
   </head>
   <body class="flex min-h-screen flex-col antialiased">
-    <header
-      style="background-color: var(--color-surface); border-bottom: 1px solid var(--color-line);"
-    >
+    <header class="border-line bg-surface border-b">
       <div
         class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:gap-6 sm:px-8"
       >
@@ -138,14 +136,12 @@ const mobileNavId = "site-mobile-nav";
           />
           <div class="min-w-0">
             <div
-              class="font-display text-xl leading-none font-bold uppercase sm:text-2xl"
-              style="color: var(--color-accent);"
+              class="font-display text-accent text-xl leading-none font-bold uppercase sm:text-2xl"
             >
               DONDETEVEO
             </div>
             <div
-              class="mt-0.5 hidden font-mono text-[9px] tracking-[0.28em] uppercase sm:block"
-              style="color: var(--color-muted);"
+              class="text-muted mt-0.5 hidden font-mono text-[9px] tracking-[0.28em] uppercase sm:block"
             >
               {dictionary.siteTagline}
             </div>
@@ -160,8 +156,7 @@ const mobileNavId = "site-mobile-nav";
               navLinks.map((link) => (
                 <a
                   href={link.href}
-                  class="nav-link font-mono text-xs tracking-[0.18em] uppercase transition-colors"
-                  style="color: var(--color-muted);"
+                  class="nav-link text-muted font-mono text-xs tracking-[0.18em] uppercase transition-colors"
                 >
                   {link.label}
                 </a>
@@ -171,8 +166,7 @@ const mobileNavId = "site-mobile-nav";
           <button
             type="button"
             data-theme-toggle
-            class="flex h-[1.625rem] w-[1.625rem] items-center justify-center border transition sm:h-[1.875rem] sm:w-[1.875rem]"
-            style="border-color: var(--color-line); background-color: var(--color-accent-dim); color: var(--color-accent); cursor: pointer;"
+            class="border-line bg-accent-dim text-accent flex h-[1.625rem] w-[1.625rem] cursor-pointer items-center justify-center border transition sm:h-[1.875rem] sm:w-[1.875rem]"
             aria-label={dictionary.switchToDarkTheme}
             data-light-label={dictionary.switchToLightTheme}
             data-dark-label={dictionary.switchToDarkTheme}
@@ -269,10 +263,7 @@ const mobileNavId = "site-mobile-nav";
       <div class="mx-auto max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
         {
           eyebrow && (
-            <div
-              class="mb-4 font-mono text-[10px] tracking-[0.3em] uppercase"
-              style="color: var(--color-muted);"
-            >
+            <div class="text-muted mb-4 font-mono text-[10px] tracking-[0.3em] uppercase">
               // {eyebrow}
             </div>
           )
@@ -280,23 +271,17 @@ const mobileNavId = "site-mobile-nav";
         <slot />
       </div>
     </main>
-    <footer
-      style="background-color: var(--color-surface); border-top: 1px solid var(--color-line);"
-    >
+    <footer class="border-line bg-surface border-t">
       <div
         class="mx-auto flex max-w-6xl flex-col gap-3 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8"
       >
         <div>
           <p
-            class="font-mono text-[10px] tracking-[0.24em] uppercase"
-            style="color: var(--color-muted);"
+            class="text-muted font-mono text-[10px] tracking-[0.24em] uppercase"
           >
             {dictionary.siteTagline}
           </p>
-          <p
-            class="mt-1 font-mono text-xs"
-            style="color: var(--color-muted); opacity: 0.8;"
-          >
+          <p class="text-muted mt-1 font-mono text-xs opacity-80">
             {dictionary.footerPunchline}
           </p>
         </div>
@@ -304,8 +289,7 @@ const mobileNavId = "site-mobile-nav";
           href={GITHUB_REPOSITORY_URL}
           target="_blank"
           rel="noopener noreferrer"
-          class="nav-link inline-flex items-center gap-2 font-mono text-xs tracking-[0.18em] uppercase transition-colors"
-          style="color: var(--color-muted);"
+          class="nav-link text-muted inline-flex items-center gap-2 font-mono text-xs tracking-[0.18em] uppercase transition-colors"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -38,8 +38,7 @@ const notFoundKeys = {
 >
   <section class="flex flex-col items-center py-20 text-center">
     <div
-      class="font-display leading-none font-bold uppercase"
-      style="font-size: clamp(6rem, 20vw, 12rem); color: var(--color-accent);"
+      class="font-display text-404 text-accent leading-none font-bold uppercase"
     >
       404
     </div>
@@ -57,8 +56,7 @@ const notFoundKeys = {
       <span class="absolute text-lg" data-runner>🏃‍➡️</span>
     </div>
     <p
-      class="mt-4 max-w-md font-mono text-base leading-8"
-      style="color: var(--color-muted);"
+      class="text-muted mt-4 max-w-md font-mono text-base leading-8"
       data-i18n="notFoundBody"
     >
       {dictionary.notFoundBody}
@@ -68,10 +66,7 @@ const notFoundKeys = {
         href={buildHomePath(locale)}
         data-i18n="notFoundGoHome"
         data-i18n-href="home"
-        class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="background-color: var(--color-coral); color: var(--color-text);"
-        onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"
-        onmouseout="this.style.backgroundColor='var(--color-coral)'"
+        class="bg-coral text-text hover:bg-coral-deep inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
       >
         {dictionary.notFoundGoHome}
       </a>
@@ -79,10 +74,7 @@ const notFoundKeys = {
         href={buildRacesPath(locale)}
         data-i18n="notFoundFindRace"
         data-i18n-href="races"
-        class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="border: 1px solid var(--color-line); color: var(--color-text);"
-        onmouseover="this.style.borderColor='var(--color-accent)'"
-        onmouseout="this.style.borderColor='var(--color-line)'"
+        class="border-line text-text hover:border-accent inline-flex border px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
       >
         {dictionary.notFoundFindRace}
       </a>

--- a/src/pages/[locale]/about.astro
+++ b/src/pages/[locale]/about.astro
@@ -25,41 +25,34 @@ const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
   description={dictionary.contactIntro}
   eyebrow={dictionary.about}
 >
-  <div
-    class="max-w-3xl"
-    style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
-  >
+  <div class="card-surface max-w-3xl">
     <h1
-      class="fade-in font-display text-5xl font-bold uppercase"
-      style="color: var(--color-accent); animation-delay: 0ms;"
+      class="fade-in font-display text-accent text-5xl font-bold uppercase"
+      style="animation-delay: 0ms;"
     >
       {dictionary.about}
     </h1>
     <p
-      class="fade-in mt-4 font-mono text-base leading-8"
-      style="color: var(--color-muted); animation-delay: 100ms;"
+      class="fade-in text-muted mt-4 font-mono text-base leading-8"
+      style="animation-delay: 100ms;"
     >
       {dictionary.contactIntro}
     </p>
     <div class="fade-in mt-6" style="animation-delay: 220ms;">
       <p
-        class="font-mono text-xs tracking-widest uppercase"
-        style="color: var(--color-muted); opacity: 0.5;"
+        class="text-muted font-mono text-xs tracking-widest uppercase opacity-50"
       >
         {dictionary.contactLabel}
       </p>
       <a
         href={`mailto:${CONTACT_EMAIL}`}
-        class="mt-1 inline-flex font-mono text-sm transition"
-        style="color: var(--color-muted);"
-        onmouseover="this.style.color='var(--color-accent)'"
-        onmouseout="this.style.color='var(--color-muted)'">{CONTACT_EMAIL}</a
+        class="text-muted hover:text-accent mt-1 inline-flex font-mono text-sm transition"
+        >{CONTACT_EMAIL}</a
       >
     </div>
     <div class="fade-in mt-6" style="animation-delay: 340ms;">
       <p
-        class="font-mono text-xs tracking-widest uppercase"
-        style="color: var(--color-muted); opacity: 0.5;"
+        class="text-muted font-mono text-xs tracking-widest uppercase opacity-50"
       >
         {dictionary.websiteLabel}
       </p>
@@ -67,17 +60,13 @@ const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
         href="https://jerna.digital"
         target="_blank"
         rel="noopener noreferrer"
-        class="mt-1 inline-flex font-mono text-sm transition"
-        style="color: var(--color-muted);"
-        onmouseover="this.style.color='var(--color-accent)'"
-        onmouseout="this.style.color='var(--color-muted)'"
+        class="text-muted hover:text-accent mt-1 inline-flex font-mono text-sm transition"
         >https://jerna.digital →</a
       >
     </div>
     <div class="fade-in mt-6" style="animation-delay: 460ms;">
       <p
-        class="font-mono text-xs tracking-widest uppercase"
-        style="color: var(--color-muted); opacity: 0.5;"
+        class="text-muted font-mono text-xs tracking-widest uppercase opacity-50"
       >
         {dictionary.githubLabel}
       </p>
@@ -85,10 +74,7 @@ const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
         href={GITHUB_REPOSITORY_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="mt-1 inline-flex font-mono text-sm transition"
-        style="color: var(--color-muted);"
-        onmouseover="this.style.color='var(--color-accent)'"
-        onmouseout="this.style.color='var(--color-muted)'"
+        class="text-muted hover:text-accent mt-1 inline-flex font-mono text-sm transition"
         >github.com/josescgar/dondeteveo →</a
       >
     </div>

--- a/src/pages/[locale]/contribute.astro
+++ b/src/pages/[locale]/contribute.astro
@@ -27,77 +27,53 @@ const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
   description={dictionary.contributeIntro}
   eyebrow={dictionary.contributeTitle}
 >
-  <div
-    class="max-w-3xl space-y-8"
-    style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
-  >
+  <div class="card-surface max-w-3xl space-y-8">
     <div>
       <h1
-        class="fade-in font-display text-5xl font-bold uppercase"
-        style="color: var(--color-accent); animation-delay: 0ms;"
+        class="fade-in font-display text-accent text-5xl font-bold uppercase"
+        style="animation-delay: 0ms;"
       >
         {dictionary.contributeTitle}
       </h1>
       <p
-        class="fade-in mt-4 font-mono text-base leading-8"
-        style="color: var(--color-muted); animation-delay: 100ms;"
+        class="fade-in text-muted mt-4 font-mono text-base leading-8"
+        style="animation-delay: 100ms;"
       >
         {dictionary.contributeIntro}
       </p>
     </div>
 
     <div class="fade-in" style="animation-delay: 220ms;">
-      <h2
-        class="font-display text-2xl font-bold uppercase"
-        style="color: var(--color-text);"
-      >
+      <h2 class="font-display text-text text-2xl font-bold uppercase">
         {dictionary.contributeViaGithub}
       </h2>
-      <p
-        class="mt-2 font-mono text-sm leading-7"
-        style="color: var(--color-muted);"
-      >
+      <p class="text-muted mt-2 font-mono text-sm leading-7">
         {dictionary.contributeViaGithubBody}
       </p>
       <a
         href={CONTRIBUTING_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="mt-3 inline-flex font-mono text-sm transition"
-        style="color: var(--color-accent);"
-        onmouseover="this.style.opacity='0.7'"
-        onmouseout="this.style.opacity='1'"
+        class="text-accent mt-3 inline-flex font-mono text-sm transition hover:opacity-70"
       >
         CONTRIBUTING.md &rarr;
       </a>
     </div>
 
     <div class="fade-in" style="animation-delay: 340ms;">
-      <h2
-        class="font-display text-2xl font-bold uppercase"
-        style="color: var(--color-text);"
-      >
+      <h2 class="font-display text-text text-2xl font-bold uppercase">
         {dictionary.contributeTools}
       </h2>
-      <p
-        class="mt-2 font-mono text-sm leading-7"
-        style="color: var(--color-muted);"
-      >
+      <p class="text-muted mt-2 font-mono text-sm leading-7">
         {dictionary.contributeToolsBody}
       </p>
-      <ul
-        class="mt-3 space-y-2 font-mono text-sm"
-        style="color: var(--color-muted);"
-      >
+      <ul class="text-muted mt-3 space-y-2 font-mono text-sm">
         <li>
           <a
             href="https://geojson.io"
             target="_blank"
             rel="noopener noreferrer"
-            class="transition"
-            style="color: var(--color-accent);"
-            onmouseover="this.style.opacity='0.7'"
-            onmouseout="this.style.opacity='1'">geojson.io</a
+            class="text-accent transition hover:opacity-70">geojson.io</a
           > — {dictionary.contributeToolGeojsonio}
         </li>
         <li>
@@ -105,10 +81,7 @@ const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
             href="https://www.plotaroute.com"
             target="_blank"
             rel="noopener noreferrer"
-            class="transition"
-            style="color: var(--color-accent);"
-            onmouseover="this.style.opacity='0.7'"
-            onmouseout="this.style.opacity='1'">plotaroute.com</a
+            class="text-accent transition hover:opacity-70">plotaroute.com</a
           > — {dictionary.contributeToolPlotaroute}
         </li>
         <li>
@@ -116,26 +89,17 @@ const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
             href="https://mapstogpx.com"
             target="_blank"
             rel="noopener noreferrer"
-            class="transition"
-            style="color: var(--color-accent);"
-            onmouseover="this.style.opacity='0.7'"
-            onmouseout="this.style.opacity='1'">mapstogpx.com</a
+            class="text-accent transition hover:opacity-70">mapstogpx.com</a
           > — {dictionary.contributeToolMapstogpx}
         </li>
       </ul>
     </div>
 
     <div class="fade-in" style="animation-delay: 460ms;">
-      <h2
-        class="font-display text-2xl font-bold uppercase"
-        style="color: var(--color-text);"
-      >
+      <h2 class="font-display text-text text-2xl font-bold uppercase">
         {dictionary.contributeRequest}
       </h2>
-      <p
-        class="mt-2 font-mono text-sm leading-7"
-        style="color: var(--color-muted);"
-      >
+      <p class="text-muted mt-2 font-mono text-sm leading-7">
         {dictionary.contributeRequestBody}
       </p>
       <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:gap-4">
@@ -143,19 +107,13 @@ const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
           href={NEW_ISSUE_URL}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex font-mono text-sm transition"
-          style="color: var(--color-accent);"
-          onmouseover="this.style.opacity='0.7'"
-          onmouseout="this.style.opacity='1'"
+          class="text-accent inline-flex font-mono text-sm transition hover:opacity-70"
         >
           {dictionary.contributeGithubIssue} &rarr;
         </a>
         <a
           href={`mailto:${CONTACT_EMAIL}`}
-          class="inline-flex font-mono text-sm transition"
-          style="color: var(--color-accent);"
-          onmouseover="this.style.opacity='0.7'"
-          onmouseout="this.style.opacity='1'"
+          class="text-accent inline-flex font-mono text-sm transition hover:opacity-70"
         >
           {dictionary.contributeEmail} &rarr;
         </a>

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -25,38 +25,27 @@ const races = (await getRaceSummaries()).map((race) =>
   description={dictionary.heroBody}
 >
   <!-- Section 1: Hero -->
-  <section class="pb-14" style="border-bottom: 1px solid var(--color-line);">
-    <div
-      class="font-mono text-[10px] tracking-[0.32em] uppercase"
-      style="color: var(--color-muted);"
-    >
+  <section class="border-line border-b pb-14">
+    <div class="text-muted font-mono text-[10px] tracking-[0.32em] uppercase">
       // {dictionary.siteTagline}
     </div>
     <div
-      class="font-display mt-3 leading-none font-bold uppercase"
-      style="font-size: clamp(3.5rem, 14vw, 9rem); color: var(--color-text);"
+      class="font-display text-hero text-text mt-3 leading-none font-bold uppercase"
     >
       DONDETEVEO
     </div>
     <h1
-      class="font-display mt-4 font-bold uppercase sm:text-5xl"
-      style="font-size: clamp(1.5rem, 5vw, 3rem); color: var(--color-accent);"
+      class="font-display text-hero-sub text-accent mt-4 font-bold uppercase sm:text-5xl"
     >
       {dictionary.heroTitle}
     </h1>
-    <p
-      class="mt-4 max-w-lg font-mono text-base leading-8"
-      style="color: var(--color-muted);"
-    >
+    <p class="text-muted mt-4 max-w-lg font-mono text-base leading-8">
       {dictionary.heroBody}
     </p>
     <div class="mt-7">
       <a
         href={buildRacesPath(locale)}
-        class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="background-color: var(--color-coral); color: var(--color-text);"
-        onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"
-        onmouseout="this.style.backgroundColor='var(--color-coral)'"
+        class="bg-coral text-text hover:bg-coral-deep inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
       >
         {dictionary.directRaceSearch}
       </a>
@@ -64,67 +53,37 @@ const races = (await getRaceSummaries()).map((race) =>
   </section>
 
   <!-- Section 2: Feature row -->
-  <section class="py-14" style="border-bottom: 1px solid var(--color-line);">
+  <section class="border-line border-b py-14">
     <div class="grid gap-8 sm:grid-cols-3">
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.searchFirstTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.searchFirstBody}
           </p>
         </div>
       </div>
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.justOpenTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.justOpenBody}
           </p>
         </div>
       </div>
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.shareReadyTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.shareReadyBody}
           </p>
         </div>
@@ -135,8 +94,7 @@ const races = (await getRaceSummaries()).map((race) =>
   <!-- Section 3: Race search -->
   <section id="race-search" class="mt-14 scroll-mt-8">
     <div
-      class="mb-5 font-mono text-[10px] tracking-[0.32em] uppercase"
-      style="color: var(--color-muted);"
+      class="text-muted mb-5 font-mono text-[10px] tracking-[0.32em] uppercase"
     >
       // {dictionary.directRaceSearch}
     </div>

--- a/src/pages/[locale]/privacy.astro
+++ b/src/pages/[locale]/privacy.astro
@@ -19,20 +19,11 @@ const dictionary = getDictionary(locale);
   description={dictionary.privacyBody}
   eyebrow={dictionary.privacy}
 >
-  <div
-    class="max-w-3xl"
-    style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
-  >
-    <h1
-      class="font-display text-5xl font-bold uppercase"
-      style="color: var(--color-accent);"
-    >
+  <div class="card-surface max-w-3xl">
+    <h1 class="font-display text-accent text-5xl font-bold uppercase">
       {dictionary.privacy}
     </h1>
-    <p
-      class="mt-4 font-mono text-base leading-8"
-      style="color: var(--color-muted);"
-    >
+    <p class="text-muted mt-4 font-mono text-base leading-8">
       {dictionary.privacyBody}
     </p>
   </div>

--- a/src/pages/[locale]/races/[race]/[year].astro
+++ b/src/pages/[locale]/races/[race]/[year].astro
@@ -58,57 +58,41 @@ const raceInfoFields = [
 >
   <section class="grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
     <div class="space-y-5">
-      <div
-        class="font-mono text-[10px] tracking-[0.32em] uppercase"
-        style="color: var(--color-muted);"
-      >
+      <div class="text-muted font-mono text-[10px] tracking-[0.32em] uppercase">
         {edition.year} — {formatDistance(edition.meta.distanceKm, locale)}
       </div>
       <h1
-        class="font-display leading-none font-bold uppercase"
-        style={`font-size: clamp(2.5rem, 8vw, 5.5rem); color: var(--color-accent);`}
+        class="font-display text-accent leading-none font-bold uppercase"
+        style="font-size: clamp(2.5rem, 8vw, 5.5rem);"
       >
         {edition.meta.name}
       </h1>
-      <p class="font-mono text-sm leading-7" style="color: var(--color-muted);">
+      <p class="text-muted font-mono text-sm leading-7">
         {edition.meta.summary}
       </p>
       {
         edition.meta.specialNote && (
-          <div style="background-color: var(--color-surface-warning); border: 1px solid var(--color-warning-line); padding: 1rem 1.25rem;">
-            <div
-              class="font-mono text-[10px] tracking-[0.28em] uppercase"
-              style="color: var(--color-warning);"
-            >
+          <div class="banner-warning">
+            <div class="text-warning font-mono text-[10px] tracking-[0.28em] uppercase">
               // {dictionary.importantRaceNote}
             </div>
-            <p
-              class="mt-3 font-mono text-sm leading-6"
-              style="color: var(--color-text);"
-            >
+            <p class="text-text mt-3 font-mono text-sm leading-6">
               {edition.meta.specialNote}
             </p>
           </div>
         )
       }
       <dl
-        class="m-0 grid gap-3 overflow-hidden px-4 py-3.5 sm:px-5 md:grid-cols-3 md:gap-4"
-        style="border: 1px solid var(--color-line);"
+        class="border-line m-0 grid gap-3 overflow-hidden border px-4 py-3.5 sm:px-5 md:grid-cols-3 md:gap-4"
         data-race-info-grid
       >
         {
           raceInfoFields.map(({ label, value }) => (
             <div class="flex min-w-0 flex-col gap-2" data-race-info-field>
-              <dt
-                class="m-0 font-mono text-[10px] tracking-[0.26em] uppercase"
-                style="color: var(--color-accent);"
-              >
+              <dt class="text-accent m-0 font-mono text-[10px] tracking-[0.26em] uppercase">
                 {label}
               </dt>
-              <dd
-                class="m-0 min-w-0 font-mono text-sm leading-6"
-                style="color: var(--color-text); overflow-wrap: anywhere;"
-              >
+              <dd class="text-text m-0 min-w-0 font-mono text-sm leading-6 [overflow-wrap:anywhere]">
                 {value}
               </dd>
             </div>
@@ -119,10 +103,7 @@ const raceInfoFields = [
         href={edition.meta.officialWebsiteUrl}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="color: var(--color-muted);"
-        onmouseover="this.style.color='var(--color-accent)'"
-        onmouseout="this.style.color='var(--color-muted)'"
+        class="text-muted hover:text-accent inline-flex font-mono text-sm tracking-[0.18em] uppercase transition"
         >{dictionary.officialWebsite} ↗</a
       >
     </div>
@@ -145,29 +126,18 @@ const raceInfoFields = [
       client:visible
     />
     <div>
-      <div
-        class="font-mono text-[10px] tracking-[0.28em] uppercase"
-        style="color: var(--color-muted);"
-      >
+      <div class="text-muted font-mono text-[10px] tracking-[0.28em] uppercase">
         // {dictionary.routeOverview}
       </div>
-      <p
-        class="mt-3 font-mono text-sm leading-6"
-        style="color: var(--color-muted);"
-      >
+      <p class="text-muted mt-3 font-mono text-sm leading-6">
         {edition.meta.heroNote}
       </p>
       <div class="mt-5">
         {
           points.map((point) => (
-            <div
-              class="flex items-center justify-between py-2.5 font-mono text-sm"
-              style="border-bottom: 1px solid var(--color-line);"
-            >
-              <span style="color: var(--color-muted);">
-                {point.properties.label}
-              </span>
-              <span style="color: var(--color-accent);">
+            <div class="border-line flex items-center justify-between border-b py-2.5 font-mono text-sm">
+              <span class="text-muted">{point.properties.label}</span>
+              <span class="text-accent">
                 {formatDistance(point.properties.distanceKm, locale)}
               </span>
             </div>

--- a/src/pages/[locale]/races/[race]/index.astro
+++ b/src/pages/[locale]/races/[race]/index.astro
@@ -81,11 +81,8 @@ const fallbackEditions = editions.toSorted((left, right) =>
       window.location.replace(raceBasePath + "/" + targetEdition.year);
     }
   </script>
-  <div
-    class="max-w-xl rounded-xl border bg-white p-6 shadow-[var(--shadow-sm)]"
-    style="border-color: var(--color-line);"
-  >
-    <p class="text-sm leading-7 text-[var(--color-muted)]">
+  <div class="border-line bg-surface max-w-xl rounded-xl border p-6 shadow-sm">
+    <p class="text-muted text-sm leading-7">
       {dictionary.latestEditionRedirect}
     </p>
     <div class="mt-4 flex flex-wrap gap-3">
@@ -93,10 +90,7 @@ const fallbackEditions = editions.toSorted((left, right) =>
         fallbackEditions.map((edition) => (
           <a
             href={buildRacePath(locale, raceSlug, edition.year)}
-            class="inline-flex rounded-lg border px-4 py-2 text-sm font-bold transition"
-            style="border-color: rgba(242,100,25,0.3); color: var(--color-orange);"
-            onmouseover="this.style.borderColor='var(--color-orange)'; this.style.backgroundColor='var(--color-amber)';"
-            onmouseout="this.style.borderColor='rgba(242,100,25,0.3)'; this.style.backgroundColor='';"
+            class="border-orange-dim text-orange hover:border-orange hover:bg-amber inline-flex rounded-lg border px-4 py-2 text-sm font-bold transition"
           >
             {edition.year}
           </a>

--- a/src/pages/[locale]/races/index.astro
+++ b/src/pages/[locale]/races/index.astro
@@ -27,15 +27,12 @@ const races = (await getRaceSummaries()).map((race) =>
 >
   <div class="max-w-3xl">
     <h1
-      class="font-display leading-none font-bold uppercase"
-      style={`font-size: clamp(2.5rem, 8vw, 4rem); color: var(--color-text);`}
+      class="font-display text-text leading-none font-bold uppercase"
+      style="font-size: clamp(2.5rem, 8vw, 4rem);"
     >
       {dictionary.discoverTitle}
     </h1>
-    <p
-      class="mt-4 font-mono text-base leading-7"
-      style="color: var(--color-muted);"
-    >
+    <p class="text-muted mt-4 font-mono text-base leading-7">
       {dictionary.discoverIntro}
     </p>
   </div>

--- a/src/pages/[locale]/share/[race]/[year].astro
+++ b/src/pages/[locale]/share/[race]/[year].astro
@@ -70,30 +70,22 @@ const sharePageRaceConnector =
   <div class="max-w-3xl">
     <h1
       id="share-h1-static"
-      class="font-display leading-none font-bold uppercase"
-      style={`font-size: clamp(2.5rem, 10vw, 5rem); color: var(--color-text);`}
+      class="font-display text-text leading-none font-bold uppercase"
+      style="font-size: clamp(2.5rem, 10vw, 5rem);"
     >
       {dictionary.sharePageTitle}{" "}<span id="share-h1-name-slot"></span>
       {sharePageRaceConnector}
       {edition.meta.name}
     </h1>
-    <p
-      class="mt-4 font-mono text-sm leading-7"
-      style="color: var(--color-muted);"
-    >
+    <p class="text-muted mt-4 font-mono text-sm leading-7">
       {dictionary.allTimesRaceLocal}
     </p>
   </div>
 
   <section class="mt-8">
     <noscript>
-      <div
-        style="background-color: var(--color-surface); border: 1px solid var(--color-line); padding: 1.5rem;"
-      >
-        <p
-          class="font-mono text-sm leading-7"
-          style="color: var(--color-muted);"
-        >
+      <div class="card-surface">
+        <p class="text-muted font-mono text-sm leading-7">
           {dictionary.shareNeedsJavaScript}
         </p>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,38 +22,27 @@ const races = (await getRaceSummaries()).map((race) =>
   description={dictionary.heroBody}
 >
   <!-- Section 1: Hero -->
-  <section class="pb-14" style="border-bottom: 1px solid var(--color-line);">
-    <div
-      class="font-mono text-[10px] tracking-[0.32em] uppercase"
-      style="color: var(--color-muted);"
-    >
+  <section class="border-line border-b pb-14">
+    <div class="text-muted font-mono text-[10px] tracking-[0.32em] uppercase">
       // {dictionary.siteTagline}
     </div>
     <div
-      class="font-display mt-3 leading-none font-bold uppercase"
-      style="font-size: clamp(3.5rem, 14vw, 9rem); color: var(--color-text);"
+      class="font-display text-hero text-text mt-3 leading-none font-bold uppercase"
     >
       DONDETEVEO
     </div>
     <h1
-      class="font-display mt-4 font-bold uppercase sm:text-5xl"
-      style="font-size: clamp(1.5rem, 5vw, 3rem); color: var(--color-accent);"
+      class="font-display text-hero-sub text-accent mt-4 font-bold uppercase sm:text-5xl"
     >
       {dictionary.heroTitle}
     </h1>
-    <p
-      class="mt-4 max-w-lg font-mono text-base leading-8"
-      style="color: var(--color-muted);"
-    >
+    <p class="text-muted mt-4 max-w-lg font-mono text-base leading-8">
       {dictionary.heroBody}
     </p>
     <div class="mt-7">
       <a
         href={buildRacesPath(locale)}
-        class="inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
-        style="background-color: var(--color-coral); color: var(--color-text);"
-        onmouseover="this.style.backgroundColor='var(--color-coral-deep)'"
-        onmouseout="this.style.backgroundColor='var(--color-coral)'"
+        class="bg-coral text-text hover:bg-coral-deep inline-flex px-5 py-2.5 font-mono text-sm tracking-[0.18em] uppercase transition"
       >
         {dictionary.directRaceSearch}
       </a>
@@ -61,67 +50,37 @@ const races = (await getRaceSummaries()).map((race) =>
   </section>
 
   <!-- Section 2: Feature row -->
-  <section class="py-14" style="border-bottom: 1px solid var(--color-line);">
+  <section class="border-line border-b py-14">
     <div class="grid gap-8 sm:grid-cols-3">
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.searchFirstTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.searchFirstBody}
           </p>
         </div>
       </div>
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.justOpenTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.justOpenBody}
           </p>
         </div>
       </div>
       <div class="flex gap-4">
-        <div
-          class="w-0.5 self-stretch"
-          style="background-color: var(--color-accent);"
-        >
-        </div>
+        <div class="bg-accent w-0.5 self-stretch"></div>
         <div>
-          <div
-            class="font-display text-base font-bold uppercase"
-            style="color: var(--color-accent);"
-          >
+          <div class="font-display text-accent text-base font-bold uppercase">
             {dictionary.shareReadyTitle}
           </div>
-          <p
-            class="mt-2 font-mono text-sm leading-7"
-            style="color: var(--color-muted);"
-          >
+          <p class="text-muted mt-2 font-mono text-sm leading-7">
             {dictionary.shareReadyBody}
           </p>
         </div>
@@ -132,8 +91,7 @@ const races = (await getRaceSummaries()).map((race) =>
   <!-- Section 3: Race search -->
   <section id="race-search" class="mt-14 scroll-mt-8">
     <div
-      class="mb-5 font-mono text-[10px] tracking-[0.32em] uppercase"
-      style="color: var(--color-muted);"
+      class="text-muted mb-5 font-mono text-[10px] tracking-[0.32em] uppercase"
     >
       // {dictionary.directRaceSearch}
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -106,22 +106,6 @@
 
 :root {
   color-scheme: light;
-  --color-bg: #f4f7fb;
-  --color-surface: #ffffff;
-  --color-surface-raised: #e6eff7;
-  --color-accent: #1e6fa0;
-  --color-accent-dim: rgba(30, 111, 160, 0.15);
-  --color-coral: #f26419;
-  --color-coral-deep: #d6560e;
-  --color-warning: #8d6d1f;
-  --color-warning-line: rgba(173, 136, 39, 0.24);
-  --color-surface-warning: #f7f2e1;
-  --color-text: #1a2e3b;
-  --color-muted: #6b7e8c;
-  --color-line: rgba(30, 111, 160, 0.14);
-  --color-line-solid: #ccd8e4;
-  --shadow-sm: 0 1px 4px rgba(30, 111, 160, 0.08);
-  --shadow-md: 0 4px 16px rgba(30, 111, 160, 0.12);
   --color-dot-pattern: rgba(30, 111, 160, 0.06);
   --color-nav-panel-start: rgba(255, 255, 255, 0.98);
   --color-nav-panel-end: rgba(230, 239, 247, 0.98);
@@ -152,11 +136,58 @@ html[data-theme="dark"] {
   --color-dot-pattern: rgba(90, 171, 219, 0.08);
   --color-nav-panel-start: rgba(22, 34, 48, 0.98);
   --color-nav-panel-end: rgba(30, 48, 68, 0.98);
+  --color-orange: #f5813a;
+  --color-orange-dim: rgba(245, 129, 58, 0.3);
+  --color-amber: rgba(245, 129, 58, 0.1);
 }
 
 @theme {
   --font-display: "Barlow Condensed", "Arial Narrow", sans-serif;
   --font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  --color-bg: #f4f7fb;
+  --color-surface: #ffffff;
+  --color-surface-raised: #e6eff7;
+  --color-accent: #1e6fa0;
+  --color-accent-dim: rgba(30, 111, 160, 0.15);
+  --color-coral: #f26419;
+  --color-coral-deep: #d6560e;
+  --color-warning: #8d6d1f;
+  --color-warning-line: rgba(173, 136, 39, 0.24);
+  --color-surface-warning: #f7f2e1;
+  --color-text: #1a2e3b;
+  --color-muted: #6b7e8c;
+  --color-line: rgba(30, 111, 160, 0.14);
+  --color-line-solid: #ccd8e4;
+  --color-orange: #f26419;
+  --color-orange-dim: rgba(242, 100, 25, 0.3);
+  --color-amber: rgba(242, 100, 25, 0.08);
+  --shadow-sm: 0 1px 4px rgba(30, 111, 160, 0.08);
+  --shadow-md: 0 4px 16px rgba(30, 111, 160, 0.12);
+}
+
+@utility card-surface {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-line);
+  padding: 1.5rem;
+}
+
+@utility banner-warning {
+  background-color: var(--color-surface-warning);
+  border: 1px solid var(--color-warning-line);
+  padding: 1rem 1.25rem;
+}
+
+@utility text-hero {
+  font-size: clamp(3.5rem, 14vw, 9rem);
+}
+
+@utility text-hero-sub {
+  font-size: clamp(1.5rem, 5vw, 3rem);
+}
+
+@utility text-404 {
+  font-size: clamp(6rem, 20vw, 12rem);
 }
 
 @keyframes raceReveal {


### PR DESCRIPTION
## Summary

- Register all `--color-*` and `--shadow-*` design tokens in Tailwind v4's `@theme` block, enabling utility classes like `text-muted`, `bg-surface`, `border-line`, `shadow-md` across the codebase
- Add `@utility` definitions for repeated multi-property patterns (`card-surface`, `banner-warning`) and `clamp()`-based font sizes (`text-hero`, `text-hero-sub`, `text-404`)
- Convert ~150 inline `style` attributes across 17 component/page files to Tailwind utility classes, reducing net lines by ~400
- Eliminate all JS-based hover/focus handlers (`onmouseover`/`onmouseout`/`onMouseOver`/`onMouseOut`/`onFocus`/`onBlur` for styling) in favor of `hover:` and `focus:` CSS variants
- Remove style string constants (`baseInputStyle`, `fieldInputStyle`) and the scoped `<style>` block with `!important` overrides in `LanguageSwitch.astro`
- Add `--color-orange`, `--color-orange-dim`, `--color-amber` tokens (with dark mode variants) for race edition links

## What stays as inline styles

- `animation-delay` values (unique per element)
- CSS triangle in `Tooltip.tsx` (one-off border trick)
- 4 unique `clamp()` font sizes that each appear once

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:unit` — 77/77 passing
- [x] `npm run build` — 24 pages built successfully
- [ ] Toggle dark mode on every page — verify colors switch correctly
- [ ] Test form inputs (search, country, year filters) for focus styling
- [ ] Test hover states on buttons (coral CTA, 404 buttons, race edition links, language switch)
- [ ] Run `npm run test:e2e` for visual regression check

No docs needed — no material changes to product behavior, architecture, or data model.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)