### PR TITLE
refactor(pages): extract inline business logic into reusable helpers (#40)

### DIFF
--- a/src/features/share-view/share-view.logic.ts
+++ b/src/features/share-view/share-view.logic.ts
@@ -1,3 +1,4 @@
+import type { Locale } from "../../lib/config";
 import type { RacePointFeature } from "../../lib/races/schemas";
 import {
   dayOffsetFromMinutes,
@@ -83,6 +84,40 @@ export const buildPredictedRouteSelection = (
     latestTime: latestClock.time,
     latestDayOffset: latestClock.dayOffset,
   };
+};
+
+export const getSpanishRaceConnector = (raceName: string): string => {
+  const normalized = raceName
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  if (
+    normalized.startsWith("carrera") ||
+    normalized.startsWith("media maraton")
+  ) {
+    return "en la";
+  }
+
+  if (
+    normalized.startsWith("maraton") ||
+    normalized.startsWith("medio maraton")
+  ) {
+    return "en el";
+  }
+
+  return "en";
+};
+
+export const getSharePageConnector = (
+  locale: Locale,
+  raceName: string,
+  fallback: string,
+): string => {
+  if (locale === "es") {
+    return getSpanishRaceConnector(raceName);
+  }
+  return fallback;
 };
 
 export const buildPredictedPoints = (

--- a/src/features/share-view/share-view.test.ts
+++ b/src/features/share-view/share-view.test.ts
@@ -4,8 +4,46 @@ import {
   CHECKPOINT_SAFETY_MARGIN_MINUTES,
   buildPredictedPoints,
   buildPredictedRouteSelection,
+  getSharePageConnector,
+  getSpanishRaceConnector,
   resolvePaceMinutesPerKm,
 } from "./share-view.logic";
+
+describe("getSpanishRaceConnector", () => {
+  it('returns "en la" for names starting with "Carrera"', () => {
+    expect(getSpanishRaceConnector("Carrera de la Mujer")).toBe("en la");
+  });
+
+  it('returns "en la" for names starting with "Media Maratón" (accent handling)', () => {
+    expect(getSpanishRaceConnector("Media Maratón de Valencia")).toBe("en la");
+  });
+
+  it('returns "en el" for names starting with "Maratón"', () => {
+    expect(getSpanishRaceConnector("Maratón de Sevilla")).toBe("en el");
+  });
+
+  it('returns "en el" for names starting with "Medio Maratón"', () => {
+    expect(getSpanishRaceConnector("Medio Maratón de Madrid")).toBe("en el");
+  });
+
+  it('returns "en" for names without a recognized prefix', () => {
+    expect(getSpanishRaceConnector("Valencia Ciudad del Running")).toBe("en");
+  });
+});
+
+describe("getSharePageConnector", () => {
+  it("returns the Spanish connector for es locale", () => {
+    expect(getSharePageConnector("es", "Maratón de Sevilla", "for the")).toBe(
+      "en el",
+    );
+  });
+
+  it("returns the fallback for en locale", () => {
+    expect(getSharePageConnector("en", "Maratón de Sevilla", "for the")).toBe(
+      "for the",
+    );
+  });
+});
 
 describe("share view logic", () => {
   it("resolves pace from a finish target", () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -35,6 +35,10 @@ export const OPEN_GRAPH_LOCALES: Record<Locale, string> = {
 
 export const LOCALE_STORAGE_KEY = "dtv-locale";
 
+export const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
+export const CONTRIBUTING_URL = `${GITHUB_REPOSITORY_URL}/blob/main/CONTRIBUTING.md`;
+export const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
+
 export const SHARE_FRAGMENT_KEYS = {
   mode: "mode",
   value: "value",

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildRaceInfoFields,
   formatCountryName,
   formatDistance,
   formatRaceDate,
@@ -27,6 +28,44 @@ describe("format helpers", () => {
   it("falls back to the normalized country code when it is not a valid region", () => {
     expect(formatCountryName("xx", "en")).toBe("XX");
     expect(formatCountryName("e1", "en")).toBe("E1");
+  });
+
+  it("builds race info fields with correct labels and values", () => {
+    const edition = {
+      date: "2026-03-15",
+      city: "Valencia",
+      startTime: "09:00",
+      timezone: "Europe/Madrid",
+    };
+    const labels = { date: "Date", city: "City", startTime: "Start time" };
+
+    const fields = buildRaceInfoFields(edition, labels, "en");
+
+    expect(fields).toHaveLength(3);
+    expect(fields[0]).toEqual({ label: "Date", value: "15 March 2026" });
+    expect(fields[1]).toEqual({ label: "City", value: "Valencia" });
+    expect(fields[2]).toEqual({
+      label: "Start time",
+      value: "09:00 (Europe/Madrid)",
+    });
+  });
+
+  it("formats the date with the correct locale in race info fields", () => {
+    const edition = {
+      date: "2026-03-15",
+      city: "Sevilla",
+      startTime: "08:30",
+      timezone: "Europe/Madrid",
+    };
+    const labels = {
+      date: "Fecha",
+      city: "Ciudad",
+      startTime: "Hora de salida",
+    };
+
+    const fields = buildRaceInfoFields(edition, labels, "es");
+
+    expect(fields[0].value).toBe("15 de marzo de 2026");
   });
 
   it("gets the calendar day in a specific timezone", () => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -50,6 +50,26 @@ export const formatCountryName = (
   );
 };
 
+export type RaceInfoField = { label: string; value: string };
+
+export const buildRaceInfoFields = (
+  edition: {
+    date: string;
+    city: string;
+    startTime: string;
+    timezone: string;
+  },
+  labels: { date: string; city: string; startTime: string },
+  locale: Locale,
+): RaceInfoField[] => [
+  { label: labels.date, value: formatRaceDate(edition.date, locale) },
+  { label: labels.city, value: edition.city },
+  {
+    label: labels.startTime,
+    value: `${edition.startTime} (${edition.timezone})`,
+  },
+];
+
 export const getTodayInTimeZone = (
   timeZone: string,
   referenceDate = new Date(),

--- a/src/pages/[locale]/about.astro
+++ b/src/pages/[locale]/about.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 import {
+  CONTACT_EMAIL,
   GITHUB_REPOSITORY_URL,
   type Locale,
   SUPPORTED_LOCALES,
@@ -14,8 +15,6 @@ export const getStaticPaths = () =>
 
 const locale = Astro.params.locale as Locale;
 const dictionary = getDictionary(locale);
-
-const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
 ---
 
 <BaseLayout

--- a/src/pages/[locale]/contribute.astro
+++ b/src/pages/[locale]/contribute.astro
@@ -2,7 +2,9 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 import {
-  GITHUB_REPOSITORY_URL,
+  CONTACT_EMAIL,
+  CONTRIBUTING_URL,
+  NEW_ISSUE_URL,
   type Locale,
   SUPPORTED_LOCALES,
 } from "../../lib/config";
@@ -14,10 +16,6 @@ export const getStaticPaths = () =>
 
 const locale = Astro.params.locale as Locale;
 const dictionary = getDictionary(locale);
-
-const CONTACT_EMAIL = "jose.escobar.dev@gmail.com";
-const CONTRIBUTING_URL = `${GITHUB_REPOSITORY_URL}/blob/main/CONTRIBUTING.md`;
-const NEW_ISSUE_URL = `${GITHUB_REPOSITORY_URL}/issues/new`;
 ---
 
 <BaseLayout

--- a/src/pages/[locale]/races/[race]/[year].astro
+++ b/src/pages/[locale]/races/[race]/[year].astro
@@ -4,7 +4,7 @@ import RaceMapIsland from "../../../../features/race-map/RaceMapIsland";
 import SharePlannerIsland from "../../../../features/share-planner/SharePlannerIsland";
 
 import { type Locale, SUPPORTED_LOCALES } from "../../../../lib/config";
-import { formatDistance, formatRaceDate } from "../../../../lib/format";
+import { buildRaceInfoFields, formatDistance } from "../../../../lib/format";
 import { buildRacePath } from "../../../../lib/routes";
 import { getDictionary } from "../../../../lib/i18n";
 import { getAllRaceEditions } from "../../../../lib/races/catalog";
@@ -33,20 +33,15 @@ const { edition: rawEdition } = Astro.props;
 const edition = localizeRaceEdition(rawEdition, locale);
 const points = getPointSummaries(edition.points);
 const pathname = buildRacePath(locale, edition.raceSlug, edition.year);
-const raceInfoFields = [
+const raceInfoFields = buildRaceInfoFields(
+  edition.meta,
   {
-    label: dictionary.date,
-    value: formatRaceDate(edition.meta.date, locale),
+    date: dictionary.date,
+    city: dictionary.city,
+    startTime: dictionary.startTime,
   },
-  {
-    label: dictionary.city,
-    value: edition.meta.city,
-  },
-  {
-    label: dictionary.startTime,
-    value: `${edition.meta.startTime} (${edition.meta.timezone})`,
-  },
-];
+  locale,
+);
 ---
 
 <BaseLayout

--- a/src/pages/[locale]/share/[race]/[year].astro
+++ b/src/pages/[locale]/share/[race]/[year].astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../../../layouts/BaseLayout.astro";
 import ShareExperienceIsland from "../../../../features/share-view/ShareExperienceIsland";
 
+import { getSharePageConnector } from "../../../../features/share-view/share-view.logic";
 import { type Locale, SUPPORTED_LOCALES } from "../../../../lib/config";
 import { getDictionary } from "../../../../lib/i18n";
 import { buildSharePath } from "../../../../lib/routes";
@@ -30,33 +31,11 @@ const { edition: rawEdition } = Astro.props;
 const edition = localizeRaceEdition(rawEdition, locale);
 const pathname = buildSharePath(locale, edition.raceSlug, edition.year);
 
-const getSpanishRaceConnector = (raceName: string): string => {
-  const normalized = raceName
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase();
-
-  if (
-    normalized.startsWith("carrera") ||
-    normalized.startsWith("media maraton")
-  ) {
-    return "en la";
-  }
-
-  if (
-    normalized.startsWith("maraton") ||
-    normalized.startsWith("medio maraton")
-  ) {
-    return "en el";
-  }
-
-  return "en";
-};
-
-const sharePageRaceConnector =
-  locale === "es"
-    ? getSpanishRaceConnector(edition.meta.name)
-    : dictionary.sharePageForThe;
+const sharePageRaceConnector = getSharePageConnector(
+  locale,
+  edition.meta.name,
+  dictionary.sharePageForThe,
+);
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary

- Extract Spanish grammar connector (`getSpanishRaceConnector`, `getSharePageConnector`) from the share page into `share-view.logic.ts`
- Extract race info fields builder (`buildRaceInfoFields`, `RaceInfoField`) from the race edition page into `format.ts`
- Move `CONTACT_EMAIL`, `CONTRIBUTING_URL`, and `NEW_ISSUE_URL` from about/contribute pages into `config.ts`

## Test plan

- [x] 7 new unit tests for Spanish connector (accent handling, all prefixes, locale fallback)
- [x] 2 new unit tests for `buildRaceInfoFields` (field structure, locale-formatted dates)
- [x] All 86 unit tests pass
- [x] All 47 e2e tests pass
- [x] Lint, format, typecheck, and build all clean

No docs needed — pure internal refactor with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)