### PR TITLE
fix(map): render base tiles in fullscreen mode

### DIFF
--- a/src/features/race-map/RaceMapIsland.tsx
+++ b/src/features/race-map/RaceMapIsland.tsx
@@ -92,9 +92,6 @@ export default function RaceMapIsland({
     const syncFullscreenState = () => {
       const active = document.fullscreenElement === wrapperRef.current;
       setIsFullscreen(active);
-      requestAnimationFrame(() => {
-        mapRef.current?.invalidateSize();
-      });
     };
 
     const mountMap = async () => {
@@ -272,6 +269,10 @@ export default function RaceMapIsland({
       .addTo(layerGroup);
   }, [panelState, pointDetails, points, raceDistanceKm, route]);
 
+  useEffect(() => {
+    mapRef.current?.invalidateSize();
+  }, [isFullscreen]);
+
   const handleDismissSelection = () => {
     setPanelState(null);
     onSelectionChange?.(null);
@@ -302,7 +303,7 @@ export default function RaceMapIsland({
   return (
     <div
       ref={wrapperRef}
-      class="border-line bg-surface relative overflow-hidden border"
+      class={`bg-surface relative overflow-hidden ${isFullscreen ? "h-screen w-screen" : "border-line h-96 border"}`}
     >
       {mode === "spectator" && canFullscreen && (
         <button
@@ -364,7 +365,7 @@ export default function RaceMapIsland({
         ref={containerRef}
         data-race-map
         data-map-mode={mode}
-        class={`w-full overflow-hidden ${isFullscreen ? "h-full" : "h-96"}`}
+        class="h-full w-full overflow-hidden"
       />
       {mode !== "static" && panelState && (
         <div


### PR DESCRIPTION
## Summary
- **Root cause**: the map container's dynamic Preact `class` prop was overwriting `leaflet-container` (and other Leaflet-injected classes) on every re-render triggered by fullscreen toggle. Without that class, Leaflet's CSS rule `.leaflet-container .leaflet-tile { max-width: none !important }` stopped matching, letting Tailwind's preflight `img { max-width: 100% }` collapse tile images to 0px width.
- **Fix**: make the map container's `class` static (`h-full w-full overflow-hidden`) so Leaflet's classes survive re-renders, and move the inline height (`h-96`) to the wrapper div which Leaflet does not modify.
- Also adds a `useEffect` on `isFullscreen` to call `invalidateSize()` after DOM commit, and removes the unreliable `requestAnimationFrame` call.

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run check` — passes
- [x] `npm run test:unit` — 86 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Manual: open share link → tap fullscreen → verify tiles render
- [ ] Manual: press Esc → verify fullscreen exits and inline map still works
- [ ] Manual: verify inline (non-fullscreen) map is unaffected

No docs needed.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)