### PR TITLE
fix(map): fix last-km display on loop courses

### DIFF
--- a/data/es/media-maraton-malaga/2026/localizations.json
+++ b/data/es/media-maraton-malaga/2026/localizations.json
@@ -4,18 +4,18 @@
       "name": "Media Maratón de Málaga",
       "city": "Málaga",
       "summary": "Media maratón por la costa de Málaga y el centro histórico, con salida y meta junto al Paseo del Parque.",
-      "heroNote": "Buenos puntos para animar en el paseo de la Malagueta, el Paseo Marítimo y la Alameda Principal cerca de la meta.",
+      "heroNote": "Buenos puntos para animar en Calle Pacífico, el Paseo Marítimo Pablo Ruiz Picasso y el Paseo Antonio Machado.",
       "specialNote": "Esta carrera tiene varias oleadas de salida, por lo que los tiempos estimados pueden ser algo menos precisos."
     },
     "pointLabels": {
       "start": "Salida - Paseo del Parque",
-      "cheer-malagueta": "Punto para animar - Playa de la Malagueta",
-      "km-5": "Punto 5K - Paseo Marítimo Pablo Ruiz Picasso",
-      "cheer-huelin": "Punto para animar - Paseo Marítimo Antonio Banderas",
-      "km-10": "Punto 10K - Avenida Juan Sebastián Elcano",
-      "km-15": "Punto 15K - Zona Calle Larios",
-      "cheer-alameda": "Punto para animar - Alameda Principal",
-      "km-20": "Punto 20K - Alameda Principal",
+      "cheer-pacifico-norte": "Punto para animar - Calle Pacífico",
+      "km-5": "Punto 5K - Calle Pacífico",
+      "cheer-pacifico-sur": "Punto para animar - Calle Pacífico",
+      "km-10": "Punto 10K - Paseo Antonio Machado",
+      "km-15": "Punto 15K - Paseo de Levante",
+      "cheer-picasso": "Punto para animar - Paseo Marítimo Pablo Ruiz Picasso",
+      "km-20": "Punto 20K - Paseo Marítimo Pablo Ruiz Picasso",
       "finish": "Meta - Paseo del Parque"
     }
   }

--- a/data/es/media-maraton-malaga/2026/points.geojson
+++ b/data/es/media-maraton-malaga/2026/points.geojson
@@ -17,8 +17,8 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "cheer-malagueta",
-        "label": "Cheer point - Playa de la Malagueta",
+        "id": "cheer-pacifico-norte",
+        "label": "Cheer point - Calle Pacífico",
         "kind": "cheer-point",
         "distanceKm": 3
       },
@@ -31,7 +31,7 @@
       "type": "Feature",
       "properties": {
         "id": "km-5",
-        "label": "5K split - Paseo Marítimo Pablo Ruiz Picasso",
+        "label": "5K split - Calle Pacífico",
         "kind": "split",
         "distanceKm": 5
       },
@@ -43,8 +43,8 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "cheer-huelin",
-        "label": "Cheer point - Paseo Marítimo Antonio Banderas",
+        "id": "cheer-pacifico-sur",
+        "label": "Cheer point - Calle Pacífico",
         "kind": "cheer-point",
         "distanceKm": 8
       },
@@ -57,7 +57,7 @@
       "type": "Feature",
       "properties": {
         "id": "km-10",
-        "label": "10K split - Avenida Juan Sebastián Elcano",
+        "label": "10K split - Paseo Antonio Machado",
         "kind": "split",
         "distanceKm": 10
       },
@@ -70,7 +70,7 @@
       "type": "Feature",
       "properties": {
         "id": "km-15",
-        "label": "15K split - Calle Larios area",
+        "label": "15K split - Paseo de Levante",
         "kind": "split",
         "distanceKm": 15
       },
@@ -82,8 +82,8 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "cheer-alameda",
-        "label": "Cheer point - Alameda Principal",
+        "id": "cheer-picasso",
+        "label": "Cheer point - Paseo Marítimo Pablo Ruiz Picasso",
         "kind": "cheer-point",
         "distanceKm": 18
       },
@@ -96,7 +96,7 @@
       "type": "Feature",
       "properties": {
         "id": "km-20",
-        "label": "20K split - Alameda Principal",
+        "label": "20K split - Paseo Marítimo Pablo Ruiz Picasso",
         "kind": "split",
         "distanceKm": 20
       },
@@ -115,7 +115,7 @@
       },
       "geometry": {
         "type": "Point",
-        "coordinates": [-4.417151, 36.718398]
+        "coordinates": [-4.415656, 36.719591]
       }
     }
   ]

--- a/src/features/race-map/RaceMapIsland.tsx
+++ b/src/features/race-map/RaceMapIsland.tsx
@@ -299,6 +299,10 @@ export default function RaceMapIsland({
     mode === "spectator" && selectedRoute
       ? (selectionTimeFormatter?.(selectedRoute.distanceKm) ?? null)
       : null;
+  const predictedReturnTime =
+    mode === "spectator" && selectedRoute?.returnPassDistanceKm != null
+      ? (selectionTimeFormatter?.(selectedRoute.returnPassDistanceKm) ?? null)
+      : null;
 
   return (
     <div
@@ -386,7 +390,9 @@ export default function RaceMapIsland({
                 class="font-display text-text mt-2 text-2xl font-bold uppercase"
               >
                 {selectedRoute
-                  ? formatExactDistance(selectedRoute.distanceKm, locale)
+                  ? selectedRoute.returnPassDistanceKm != null
+                    ? `${formatExactDistance(selectedRoute.returnPassDistanceKm, locale)} / ${formatExactDistance(selectedRoute.distanceKm, locale)}`
+                    : formatExactDistance(selectedRoute.distanceKm, locale)
                   : selectedMarker?.label}
               </div>
             </div>
@@ -402,12 +408,33 @@ export default function RaceMapIsland({
           </div>
           {selectedRoute && (
             <div data-route-selection-distance class="hidden">
-              {formatExactDistance(selectedRoute.distanceKm, locale)}
+              {selectedRoute.returnPassDistanceKm != null
+                ? `${formatExactDistance(selectedRoute.returnPassDistanceKm, locale)} / ${formatExactDistance(selectedRoute.distanceKm, locale)}`
+                : formatExactDistance(selectedRoute.distanceKm, locale)}
             </div>
           )}
           {mode === "spectator" && predictedPassingTime && selectedRoute && (
             <div class="text-text mt-4 font-mono text-sm">
-              <span data-route-selection-time>{predictedPassingTime}</span>
+              {predictedReturnTime ? (
+                <div class="flex flex-col gap-1">
+                  <div>
+                    <span class="text-muted mr-2">
+                      {dictionary.firstPassLabel}
+                    </span>
+                    <span data-route-selection-time>{predictedReturnTime}</span>
+                  </div>
+                  <div>
+                    <span class="text-muted mr-2">
+                      {dictionary.returnPassLabel}
+                    </span>
+                    <span data-route-selection-return-time>
+                      {predictedPassingTime}
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <span data-route-selection-time>{predictedPassingTime}</span>
+              )}
             </div>
           )}
           {selectedMarker?.detail && (

--- a/src/features/race-map/race-map.logic.ts
+++ b/src/features/race-map/race-map.logic.ts
@@ -14,6 +14,7 @@ export type RaceMapMarker = {
 export type RouteSelection = {
   coordinates: [number, number];
   distanceKm: number;
+  returnPassDistanceKm?: number;
 };
 
 type RouteSelectionCandidate = RouteSelection & {
@@ -30,7 +31,7 @@ type RouteSegment = {
 
 const EARTH_RADIUS_METERS = 6_371_000;
 const ROUTE_SELECTION_TIE_TOLERANCE_METERS = 0.5;
-const AMBIGUOUS_SELECTION_DISTANCE_THRESHOLD_KM = 0.1;
+const AMBIGUOUS_SELECTION_DISTANCE_THRESHOLD_KM = 0.5;
 
 export const DEFAULT_ROUTE_SELECTION_TOLERANCE_METERS = 90;
 
@@ -177,7 +178,7 @@ export const getRouteSelection = (
   const projectedCoordinate = projectCoordinate(coordinate, referenceLatitude);
   let closestSelection: RouteSelectionCandidate | null = null;
   let closestDistanceFromRouteMeters = Number.POSITIVE_INFINITY;
-  let hasAmbiguousMatch = false;
+  let returnPassRawDistanceKm: number | null = null;
 
   for (const segment of segments) {
     const projectedStart = projectCoordinate(segment.start, referenceLatitude);
@@ -221,7 +222,18 @@ export const getRouteSelection = (
           Math.abs(rawDistanceKm - closestSelection.rawDistanceKm) >
           AMBIGUOUS_SELECTION_DISTANCE_THRESHOLD_KM
         ) {
-          hasAmbiguousMatch = true;
+          returnPassRawDistanceKm ??= closestSelection.rawDistanceKm;
+          closestSelection = {
+            coordinates: [snappedCoordinate[1], snappedCoordinate[0]],
+            distanceKm: scaleRouteDistance(
+              rawDistanceKm,
+              totalRouteDistanceKm,
+              raceDistanceKm,
+            ),
+            distanceFromRouteMeters,
+            rawDistanceKm,
+          };
+          closestDistanceFromRouteMeters = distanceFromRouteMeters;
         }
 
         continue;
@@ -232,7 +244,7 @@ export const getRouteSelection = (
       }
     }
 
-    hasAmbiguousMatch = false;
+    returnPassRawDistanceKm = null;
 
     closestSelection = {
       coordinates: [snappedCoordinate[1], snappedCoordinate[0]],
@@ -249,7 +261,6 @@ export const getRouteSelection = (
 
   if (
     !closestSelection ||
-    hasAmbiguousMatch ||
     closestDistanceFromRouteMeters > maxSnapDistanceMeters
   ) {
     return null;
@@ -258,6 +269,13 @@ export const getRouteSelection = (
   return {
     coordinates: closestSelection.coordinates,
     distanceKm: closestSelection.distanceKm,
+    ...(returnPassRawDistanceKm != null && {
+      returnPassDistanceKm: scaleRouteDistance(
+        returnPassRawDistanceKm,
+        totalRouteDistanceKm,
+        raceDistanceKm,
+      ),
+    }),
   };
 };
 

--- a/src/features/race-map/race-map.test.ts
+++ b/src/features/race-map/race-map.test.ts
@@ -91,7 +91,7 @@ describe("race map logic", () => {
     expect(selection).toBeNull();
   });
 
-  it("returns null for ambiguous overlapping route selections", () => {
+  it("returns both passes for overlapping route selections", () => {
     const overlappingRoute = {
       type: "FeatureCollection" as const,
       features: [
@@ -129,6 +129,40 @@ describe("race map logic", () => {
       DEFAULT_ROUTE_SELECTION_TOLERANCE_METERS,
     );
 
-    expect(selection).toBeNull();
+    expect(selection).not.toBeNull();
+    expect(selection?.distanceKm).toBeCloseTo(7.5, 0);
+    expect(selection?.returnPassDistanceKm).toBeCloseTo(2.5, 0);
+  });
+
+  it("does not produce a return pass for consecutive segments within the ambiguity threshold", () => {
+    const tightRoute = {
+      type: "FeatureCollection" as const,
+      features: [
+        {
+          type: "Feature" as const,
+          properties: {},
+          geometry: {
+            type: "LineString" as const,
+            coordinates: [
+              [-5.99, 37.38],
+              [-5.988, 37.38],
+              [-5.986, 37.38],
+              [-5.984, 37.38],
+            ],
+          },
+        },
+      ],
+    } satisfies RaceRouteCollection;
+
+    const selection = getRouteSelection(
+      tightRoute,
+      [-5.987, 37.38],
+      10,
+      DEFAULT_ROUTE_SELECTION_TOLERANCE_METERS,
+    );
+
+    expect(selection).not.toBeNull();
+    expect(selection?.distanceKm).toBeDefined();
+    expect(selection?.returnPassDistanceKm).toBeUndefined();
   });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -103,6 +103,8 @@ type Dictionary = {
   notFoundBody: string;
   notFoundGoHome: string;
   notFoundFindRace: string;
+  firstPassLabel: string;
+  returnPassLabel: string;
   loadMore: string;
 };
 
@@ -229,6 +231,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
       "The page you\u2019re looking for doesn\u2019t exist or may have moved.",
     notFoundGoHome: "Go to homepage",
     notFoundFindRace: "Find your race",
+    firstPassLabel: "1st pass",
+    returnPassLabel: "Return",
     loadMore: "Load more",
   },
   es: {
@@ -355,6 +359,8 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     notFoundBody: "La p\u00e1gina que buscas no existe o puede haberse movido.",
     notFoundGoHome: "Ir al inicio",
     notFoundFindRace: "Encuentra tu carrera",
+    firstPassLabel: "1ª pasada",
+    returnPassLabel: "Vuelta",
     loadMore: "Cargar más",
   },
 };


### PR DESCRIPTION
## Summary
- Fix route selection on loop courses where the last ~1 km overlaps with the first ~1 km (e.g. Málaga half marathon start/finish at Paseo del Parque)
- Raise ambiguity threshold from 0.1 to 0.5 km to prevent consecutive segments from falsely triggering return pass detection
- Promote the later candidate to primary on real overlaps, so clicking near the finish shows ~km 21 instead of ~km 0
- Display both pass distances in the info box (e.g. "0.05 km / 21.05 km") when a route selection has two passes
- Fix "Meta - Paseo del Parque" finish point coordinates to match the actual route endpoint
- Update cheer point names and localizations for Málaga 2026
- Add i18n strings for first/return pass labels

## Test plan
- [x] `npm run test:unit` — 87 tests pass
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — clean
- [ ] Manual: click last km of Málaga route → shows ~km 20-21, not km 0-1
- [ ] Manual: click start/finish overlap → shows two distances and two pass times in spectator mode
- [ ] Manual: verify finish marker is placed at the actual route end

No docs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)