### PR TITLE
feat(discovery): add city filter to race discovery page

### DIFF
--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -12,6 +12,7 @@ import type { RaceSummary } from "../../lib/races/catalog";
 import {
   filterDiscoveryCards,
   getDiscoveryCards,
+  getDiscoveryCityOptions,
   getDiscoveryCountryOptions,
   paginateDiscoveryCards,
 } from "./race-discovery.logic";
@@ -28,6 +29,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
   const dictionary = getDictionary(locale);
   const [query, setQuery] = useState("");
   const [country, setCountry] = useState("");
+  const [city, setCity] = useState("");
   const [year, setYear] = useState("");
   const [visibleCount, setVisibleCount] = useState(DISCOVERY_PAGE_SIZE);
 
@@ -36,8 +38,8 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
     [locale, races],
   );
   const filteredCards = useMemo(
-    () => filterDiscoveryCards(cards, { query, country, year }),
-    [cards, country, query, year],
+    () => filterDiscoveryCards(cards, { query, country, city, year }),
+    [cards, country, city, query, year],
   );
   const visibleCards = useMemo(
     () => paginateDiscoveryCards(filteredCards, visibleCount),
@@ -47,12 +49,18 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
     () => getDiscoveryCountryOptions(locale, races),
     [locale, races],
   );
+  const availableCities = useMemo(() => {
+    const filteredRaces = country
+      ? races.filter((race) => race.countryCode === country)
+      : races;
+    return getDiscoveryCityOptions(filteredRaces, locale);
+  }, [races, country, locale]);
 
   const availableYears = [...new Set(races.map((race) => race.year))].sort();
 
   return (
     <div class="space-y-6">
-      <div class="grid gap-6 md:grid-cols-[2fr_1fr_1fr]">
+      <div class="grid gap-6 md:grid-cols-[2fr_1fr_1fr_1fr]">
         <label class="flex flex-col gap-1.5">
           <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.search}
@@ -76,6 +84,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             value={country}
             onInput={(event) => {
               setCountry(event.currentTarget.value);
+              setCity("");
               setVisibleCount(DISCOVERY_PAGE_SIZE);
             }}
             class={inputClass}
@@ -83,6 +92,24 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             <option value="">{dictionary.allFilter}</option>
             {availableCountries.map((country) => (
               <option value={country.value}>{country.label}</option>
+            ))}
+          </select>
+        </label>
+        <label class="flex flex-col gap-1.5">
+          <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
+            {dictionary.city}
+          </span>
+          <select
+            value={city}
+            onInput={(event) => {
+              setCity(event.currentTarget.value);
+              setVisibleCount(DISCOVERY_PAGE_SIZE);
+            }}
+            class={inputClass}
+          >
+            <option value="">{dictionary.allFilter}</option>
+            {availableCities.map((cityOption) => (
+              <option value={cityOption.value}>{cityOption.label}</option>
             ))}
           </select>
         </label>

--- a/src/features/race-discovery/race-discovery.logic.ts
+++ b/src/features/race-discovery/race-discovery.logic.ts
@@ -6,6 +6,7 @@ import type { RaceSummary } from "../../lib/races/catalog";
 export type DiscoveryFilters = {
   query: string;
   country: string;
+  city: string;
   year: string;
 };
 
@@ -13,7 +14,7 @@ export type DiscoveryCard = RaceSummary & {
   href: string;
 };
 
-export type DiscoveryCountryOption = {
+export type DiscoveryFilterOption = {
   value: string;
   label: string;
 };
@@ -30,7 +31,7 @@ export const getDiscoveryCards = (
 export const getDiscoveryCountryOptions = (
   locale: Locale,
   races: RaceSummary[],
-): DiscoveryCountryOption[] =>
+): DiscoveryFilterOption[] =>
   [...new Set(races.map((race) => race.countryCode))]
     .map((countryCode) => ({
       value: countryCode,
@@ -41,6 +42,14 @@ export const getDiscoveryCountryOptions = (
         left.label.localeCompare(right.label, locale) ||
         left.value.localeCompare(right.value),
     );
+
+export const getDiscoveryCityOptions = (
+  races: RaceSummary[],
+  locale?: Locale,
+): DiscoveryFilterOption[] =>
+  [...new Set(races.map((race) => race.meta.city))]
+    .map((city) => ({ value: city, label: city }))
+    .sort((left, right) => left.label.localeCompare(right.label, locale));
 
 export const paginateDiscoveryCards = (
   cards: DiscoveryCard[],
@@ -59,8 +68,10 @@ export const filterDiscoveryCards = (
       card.meta.name.toLowerCase().includes(normalizedQuery);
     const matchesCountry =
       filters.country.length === 0 || card.countryCode === filters.country;
+    const matchesCity =
+      filters.city.length === 0 || card.meta.city === filters.city;
     const matchesYear = filters.year.length === 0 || card.year === filters.year;
 
-    return matchesQuery && matchesCountry && matchesYear;
+    return matchesQuery && matchesCountry && matchesCity && matchesYear;
   });
 };

--- a/src/features/race-discovery/race-discovery.test.ts
+++ b/src/features/race-discovery/race-discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   filterDiscoveryCards,
+  getDiscoveryCityOptions,
   getDiscoveryCountryOptions,
   paginateDiscoveryCards,
 } from "./race-discovery.logic";
@@ -65,6 +66,7 @@ describe("race discovery logic", () => {
     const result = filterDiscoveryCards(cards, {
       query: "triana",
       country: "",
+      city: "",
       year: "",
     });
 
@@ -75,6 +77,7 @@ describe("race discovery logic", () => {
     const result = filterDiscoveryCards(cards, {
       query: "",
       country: "es",
+      city: "",
       year: "",
     });
 
@@ -103,9 +106,75 @@ describe("race discovery logic", () => {
     const result = filterDiscoveryCards(cards, {
       query: "madrid",
       country: "",
+      city: "",
       year: "",
     });
 
     expect(result).toHaveLength(0);
+  });
+
+  it("builds sorted unique city options", () => {
+    const races = [
+      cards[0],
+      {
+        ...cards[0],
+        raceSlug: "malaga-half",
+        meta: { ...cards[0].meta, city: "Málaga" },
+      },
+      {
+        ...cards[0],
+        raceSlug: "seville-half",
+        meta: { ...cards[0].meta, city: "Seville" },
+      },
+    ];
+
+    expect(getDiscoveryCityOptions(races)).toEqual([
+      { value: "Málaga", label: "Málaga" },
+      { value: "Seville", label: "Seville" },
+    ]);
+  });
+
+  it("filters cards by city", () => {
+    const result = filterDiscoveryCards(cards, {
+      query: "",
+      country: "",
+      city: "Seville",
+      year: "",
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns no cards when city does not match", () => {
+    const result = filterDiscoveryCards(cards, {
+      query: "",
+      country: "",
+      city: "Madrid",
+      year: "",
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("composes city filter with other filters", () => {
+    const multiCards = [
+      cards[0],
+      {
+        ...cards[0],
+        countryCode: "fr",
+        raceSlug: "paris-marathon",
+        meta: { ...cards[0].meta, city: "Paris" },
+      },
+    ];
+
+    const result = filterDiscoveryCards(multiCards, {
+      query: "",
+      country: "es",
+      city: "Seville",
+      year: "2026",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raceSlug).toBe("carrera-triana-los-remedios-10k");
   });
 });


### PR DESCRIPTION
## Summary
- Add city dropdown filter to race discovery page, composing with existing search, country, and year filters
- Cities are scoped to the selected country and reset when the country changes
- 4 new unit tests covering city options, filtering, no-match, and filter composition

Closes #86

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run check` passes (0 errors)
- [x] `npm run test:unit` passes (91 tests)
- [x] `npm run build` succeeds
- [ ] Manual: verify city dropdown appears and filters correctly
- [ ] Manual: verify city resets when country changes
- [ ] Manual: verify city composes with text search and year filters

No docs needed — no material changes to product behavior, architecture, or data model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)