### PR TITLE
feat(seo): improve sitemap discoverability

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dondeteveo.com/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -90,6 +90,7 @@ const mobileNavId = "site-mobile-nav";
     {seo.noindex && <meta name="robots" content="noindex,follow" />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="sitemap" href="/sitemap-index.xml" />
     <script is:inline define:vars={{ themeKey: THEME_STORAGE_KEY }}>
       (function () {
         let stored;


### PR DESCRIPTION
## Summary
- Add `robots.txt` with a `Sitemap:` directive pointing to `sitemap-index.xml`
- Add `<link rel="sitemap">` to the HTML `<head>` in `BaseLayout.astro`

Both provide crawler discoverability for the sitemap generated by `@astrojs/sitemap`, which previously required manual submission via Search Console.

## Test plan
- [x] `npm run build` succeeds — `dist/robots.txt` present, `<link rel="sitemap">` in built HTML
- [ ] Verify `/robots.txt` is served correctly after deploy

No docs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)