### PR TITLE
feat(map): enable scroll wheel zoom

### DIFF
--- a/src/features/race-map/RaceMapIsland.tsx
+++ b/src/features/race-map/RaceMapIsland.tsx
@@ -103,7 +103,7 @@ export default function RaceMapIsland({
 
       leafletRef.current = leaflet;
       mapRef.current = leaflet.map(containerRef.current, {
-        scrollWheelZoom: false,
+        scrollWheelZoom: true,
       });
 
       setCanFullscreen(Boolean(wrapperRef.current?.requestFullscreen));


### PR DESCRIPTION
## Summary
- Enable mousewheel zoom on the Leaflet map by changing `scrollWheelZoom: false` to `true`
- Pinch-to-zoom on touch devices is unaffected (`touchZoom` is a separate Leaflet option, enabled by default)
- Works in both inline and fullscreen map modes

Closes #106

## Code review notes
Code review agent flagged a scroll-hijacking concern: when the cursor is over the inline map, scrolling zooms the map instead of scrolling the page. This is the expected behavior per issue #106. A future enhancement could use a click-to-enable pattern if users find it disruptive.

## Test plan
- [x] Scroll over the map on a race edition page → zoom changes
- [x] Scroll outside the map → page scrolls normally
- [x] Pinch zoom on touch device → still works
- [x] Enter fullscreen and scroll → zoom works
- [x] `npm run lint && npm run format:check && npm run check && npm run test:unit && npm run build` passes

No docs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)