### PR TITLE
feat(discovery): add include-past-races filter defaulting to off

### DIFF
--- a/src/features/race-discovery/DiscoveryListIsland.tsx
+++ b/src/features/race-discovery/DiscoveryListIsland.tsx
@@ -31,6 +31,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
   const [country, setCountry] = useState("");
   const [city, setCity] = useState("");
   const [year, setYear] = useState("");
+  const [includePast, setIncludePast] = useState(false);
   const [visibleCount, setVisibleCount] = useState(DISCOVERY_PAGE_SIZE);
 
   const cards = useMemo(
@@ -38,8 +39,9 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
     [locale, races],
   );
   const filteredCards = useMemo(
-    () => filterDiscoveryCards(cards, { query, country, city, year }),
-    [cards, country, city, query, year],
+    () =>
+      filterDiscoveryCards(cards, { query, country, city, year, includePast }),
+    [cards, country, city, query, year, includePast],
   );
   const visibleCards = useMemo(
     () => paginateDiscoveryCards(filteredCards, visibleCount),
@@ -60,7 +62,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
 
   return (
     <div class="space-y-6">
-      <div class="grid gap-6 md:grid-cols-[2fr_1fr_1fr_1fr]">
+      <div class="grid gap-6 md:grid-cols-[2fr_1fr_1fr]">
         <label class="flex flex-col gap-1.5">
           <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.search}
@@ -76,7 +78,7 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
             class={inputClass}
           />
         </label>
-        <label class="flex flex-col gap-1.5">
+        <label class="hidden flex-col gap-1.5">
           <span class="text-muted font-mono text-[10px] tracking-[0.26em] uppercase">
             {dictionary.country}
           </span>
@@ -132,6 +134,19 @@ export default function DiscoveryListIsland({ locale, races }: Props) {
           </select>
         </label>
       </div>
+
+      <label class="text-muted flex items-center gap-2 font-mono text-sm">
+        <input
+          type="checkbox"
+          checked={includePast}
+          onInput={(event) => {
+            setIncludePast(event.currentTarget.checked);
+            setVisibleCount(DISCOVERY_PAGE_SIZE);
+          }}
+          class="accent-accent"
+        />
+        {dictionary.includePastRaces}
+      </label>
 
       <div>
         {filteredCards.length > 0 ? (

--- a/src/features/race-discovery/race-discovery.logic.ts
+++ b/src/features/race-discovery/race-discovery.logic.ts
@@ -1,5 +1,5 @@
 import type { Locale } from "../../lib/config";
-import { formatCountryName } from "../../lib/format";
+import { formatCountryName, getTodayInTimeZone } from "../../lib/format";
 import { buildRacePath } from "../../lib/routes";
 import type { RaceSummary } from "../../lib/races/catalog";
 
@@ -8,6 +8,7 @@ export type DiscoveryFilters = {
   country: string;
   city: string;
   year: string;
+  includePast: boolean;
 };
 
 export type DiscoveryCard = RaceSummary & {
@@ -71,7 +72,16 @@ export const filterDiscoveryCards = (
     const matchesCity =
       filters.city.length === 0 || card.meta.city === filters.city;
     const matchesYear = filters.year.length === 0 || card.year === filters.year;
+    const matchesPast =
+      filters.includePast ||
+      card.meta.date >= getTodayInTimeZone(card.meta.timezone);
 
-    return matchesQuery && matchesCountry && matchesCity && matchesYear;
+    return (
+      matchesQuery &&
+      matchesCountry &&
+      matchesCity &&
+      matchesYear &&
+      matchesPast
+    );
   });
 };

--- a/src/features/race-discovery/race-discovery.test.ts
+++ b/src/features/race-discovery/race-discovery.test.ts
@@ -68,6 +68,7 @@ describe("race discovery logic", () => {
       country: "",
       city: "",
       year: "",
+      includePast: true,
     });
 
     expect(result).toHaveLength(1);
@@ -79,6 +80,7 @@ describe("race discovery logic", () => {
       country: "es",
       city: "",
       year: "",
+      includePast: true,
     });
 
     expect(result).toHaveLength(1);
@@ -108,6 +110,7 @@ describe("race discovery logic", () => {
       country: "",
       city: "",
       year: "",
+      includePast: true,
     });
 
     expect(result).toHaveLength(0);
@@ -140,6 +143,7 @@ describe("race discovery logic", () => {
       country: "",
       city: "Seville",
       year: "",
+      includePast: true,
     });
 
     expect(result).toHaveLength(1);
@@ -151,9 +155,96 @@ describe("race discovery logic", () => {
       country: "",
       city: "Madrid",
       year: "",
+      includePast: true,
     });
 
     expect(result).toHaveLength(0);
+  });
+
+  it("hides past races by default when includePast is false", () => {
+    const pastCard = {
+      ...cards[0],
+      raceSlug: "past-race",
+      href: "/en/races/past-race/2024",
+      meta: { ...cards[0].meta, date: "2024-01-01" },
+    };
+    const futureCard = {
+      ...cards[0],
+      raceSlug: "future-race",
+      href: "/en/races/future-race/2027",
+      meta: { ...cards[0].meta, date: "2027-06-01" },
+    };
+
+    const result = filterDiscoveryCards([pastCard, futureCard], {
+      query: "",
+      country: "",
+      city: "",
+      year: "",
+      includePast: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raceSlug).toBe("future-race");
+  });
+
+  it("shows all races when includePast is true", () => {
+    const pastCard = {
+      ...cards[0],
+      raceSlug: "past-race",
+      href: "/en/races/past-race/2024",
+      meta: { ...cards[0].meta, date: "2024-01-01" },
+    };
+    const futureCard = {
+      ...cards[0],
+      raceSlug: "future-race",
+      href: "/en/races/future-race/2027",
+      meta: { ...cards[0].meta, date: "2027-06-01" },
+    };
+
+    const result = filterDiscoveryCards([pastCard, futureCard], {
+      query: "",
+      country: "",
+      city: "",
+      year: "",
+      includePast: true,
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("composes includePast filter with other filters", () => {
+    const pastCard = {
+      ...cards[0],
+      raceSlug: "past-seville",
+      href: "/en/races/past-seville/2024",
+      meta: { ...cards[0].meta, date: "2024-01-01", city: "Seville" },
+    };
+    const futureMadrid = {
+      ...cards[0],
+      raceSlug: "future-madrid",
+      href: "/en/races/future-madrid/2027",
+      meta: { ...cards[0].meta, date: "2027-06-01", city: "Madrid" },
+    };
+    const futureSeville = {
+      ...cards[0],
+      raceSlug: "future-seville",
+      href: "/en/races/future-seville/2027",
+      meta: { ...cards[0].meta, date: "2027-06-01", city: "Seville" },
+    };
+
+    const result = filterDiscoveryCards(
+      [pastCard, futureMadrid, futureSeville],
+      {
+        query: "",
+        country: "",
+        city: "Seville",
+        year: "",
+        includePast: false,
+      },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raceSlug).toBe("future-seville");
   });
 
   it("composes city filter with other filters", () => {
@@ -172,6 +263,7 @@ describe("race discovery logic", () => {
       country: "es",
       city: "Seville",
       year: "2026",
+      includePast: true,
     });
 
     expect(result).toHaveLength(1);

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -108,6 +108,7 @@ type Dictionary = {
   loadMore: string;
   startWave: string;
   selectWave: string;
+  includePastRaces: string;
 };
 
 const DICTIONARIES: Record<Locale, Dictionary> = {
@@ -238,6 +239,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     loadMore: "Load more",
     startWave: "Start wave",
     selectWave: "Select your wave (optional)",
+    includePastRaces: "Include past races",
   },
   es: {
     about: "Acerca de",
@@ -368,6 +370,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     loadMore: "Cargar más",
     startWave: "Cajón de salida",
     selectWave: "Selecciona tu cajón (opcional)",
+    includePastRaces: "Incluir carreras pasadas",
   },
 };
 


### PR DESCRIPTION
## Summary
- Race discovery now hides past editions by default, reducing noise for users looking for upcoming races
- Adds a checkbox toggle ("Include past races" / "Incluir carreras pasadas") below the filter grid to opt in to viewing past editions
- Hides the Country dropdown from UI (keeps state/logic intact) and adjusts filter grid to 3 columns

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run check` passes (0 errors)
- [x] `npm run test:unit` passes (112 tests, including 3 new tests for the filter)
- [x] `npm run build` succeeds
- [ ] Manual: load `/en/races`, confirm past races are hidden by default
- [ ] Manual: enable "Include past races" toggle, confirm past races appear
- [ ] Manual: verify toggle composes correctly with search, city, and year filters

Closes #111

No docs needed — no material change to architecture, workflow, or data model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)