### PR TITLE
feat(share-view): add official website link to share page

### DIFF
--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -362,6 +362,18 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
           {effectiveStartTime}
           <span class="ml-2">({edition.meta.timezone})</span>
         </div>
+        {edition.meta.officialWebsiteUrl && (
+          <div class="mt-3">
+            <a
+              href={edition.meta.officialWebsiteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-accent font-mono text-xs tracking-[0.2em] uppercase underline underline-offset-4 hover:no-underline"
+            >
+              {dictionary.officialWebsite} ↗
+            </a>
+          </div>
+        )}
         {edition.meta.specialNote && (
           <div class="banner-warning mt-4">
             <div class="text-warning font-mono text-[10px] tracking-[0.28em] uppercase">


### PR DESCRIPTION
## Summary
- Adds an official website link to the share page runner header band, between the start time and the special note banner
- Uses existing `dictionary.officialWebsite` i18n label with ↗ arrow, opens in new tab
- Conditionally rendered for defensive correctness, styled consistently with the share page's mono/uppercase design language

Closes #112

## Test plan
- [x] Lint, format, typecheck, unit tests all pass
- [x] Production build succeeds
- [ ] Manual: verify link appears on share pages and opens in new tab
- [ ] Manual: verify mobile and desktop rendering

No docs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)