### PR TITLE
feat(layout): add Cloudflare Web Analytics beacon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Cloudflare Web Analytics beacon token.
+# Provisioned in the Cloudflare dashboard (Analytics & Logs -> Web Analytics -> Manual setup).
+# Leave empty to disable analytics; the site builds and runs without it.
+# In CI, the GitHub Actions secret must be named `PUBLIC_CF_ANALYTICS_TOKEN` to match.
+PUBLIC_CF_ANALYTICS_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build site
+        env:
+          PUBLIC_CF_ANALYTICS_TOKEN: ${{ secrets.PUBLIC_CF_ANALYTICS_TOKEN }}
         run: npm run build
 
       - name: Upload GitHub Pages artifact

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,6 +26,10 @@ const {
   eyebrow,
 } = Astro.props;
 const dictionary = getDictionary(locale as Locale);
+const analyticsToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
+const analyticsBeacon = analyticsToken
+  ? JSON.stringify({ token: analyticsToken })
+  : null;
 const seo = buildSeo({
   locale,
   title,
@@ -111,6 +115,16 @@ const mobileNavId = "site-mobile-nav";
         }
       })();
     </script>
+    {
+      analyticsBeacon && (
+        <script
+          is:inline
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon={analyticsBeacon}
+        />
+      )
+    }
   </head>
   <body class="flex min-h-screen flex-col antialiased">
     <header class="border-line bg-surface border-b">

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -177,7 +177,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     predictedTimes: "Predicted times",
     privacy: "Privacy",
     privacyBody:
-      "This MVP keeps sharing simple. Personalized pages are public by URL, never indexed, and may still involve third-party services such as Cloudflare and map providers.",
+      "This MVP keeps sharing simple. Personalized pages are public by URL, never indexed, and may still involve third-party services such as Cloudflare (including cookieless aggregate traffic analytics) and map providers.",
     raceDiscovery: "Race discovery",
     raceLocalTime: "Race local time",
     raceSearchPlaceholder: "Search by race name",
@@ -309,7 +309,7 @@ const DICTIONARIES: Record<Locale, Dictionary> = {
     predictedTimes: "Horarios estimados",
     privacy: "Privacidad",
     privacyBody:
-      "Hemos querido mantenerlo simple. Las páginas personalizadas son públicas por URL, nunca se indexan y pueden pasar por servicios de terceros como Cloudflare y proveedores de mapas.",
+      "Hemos querido mantenerlo simple. Las páginas personalizadas son públicas por URL, nunca se indexan y pueden pasar por servicios de terceros como Cloudflare (incluidas analíticas agregadas sin cookies) y proveedores de mapas.",
     raceDiscovery: "Encontrar carreras",
     raceLocalTime: "Hora local de la carrera",
     raceSearchPlaceholder: "Busca por nombre de carrera",


### PR DESCRIPTION
## Summary

Adds cookieless, consent-free aggregate analytics so we can finally see pageview volumes, top races, and referrer mix without identifying individuals or standing up a new privacy review. Cloudflare Web Analytics fits the existing stack (the site is already behind Cloudflare) and the existing `/privacy` disclosure.

## Changes

- `src/layouts/BaseLayout.astro` — reads `PUBLIC_CF_ANALYTICS_TOKEN` from `import.meta.env`; when set, renders the CFWA beacon `<script>` once in `<head>` on every page. When unset, emits nothing (keeps dev/preview/fork builds clean). Token is wrapped in `JSON.stringify` for safe attribute interpolation.
- `src/lib/i18n.ts` — `privacyBody` in both locales now explicitly names cookieless aggregate traffic analytics alongside the existing Cloudflare mention on `/privacy`.
- `.env.example` — new file, documents `PUBLIC_CF_ANALYTICS_TOKEN` and notes the GitHub Actions secret must use the same name.
- `.github/workflows/ci.yml` — `deploy` job's `Build site` step now exposes `PUBLIC_CF_ANALYTICS_TOKEN` from the secret of the same name. The `quality.Build` step is deliberately left alone so PR CI / fork builds never emit the beacon.

### Owner follow-up (one-time)

Before the beacon starts reporting, provision:
1. Cloudflare dashboard → Analytics & Logs → Web Analytics → add `dondeteveo.com` (manual setup).
2. Copy the `token` value.
3. GitHub → Settings → Secrets and variables → Actions → new secret **named exactly `PUBLIC_CF_ANALYTICS_TOKEN`**, value = the token.

## Test Plan

- [ ] `npm run lint` passes (CI)
- [ ] `npm run format:check` passes (CI)
- [ ] `npm run check` passes (CI)
- [ ] `npm run test:unit` passes (CI)
- [ ] `npm run build` succeeds (CI)
- [ ] E2E smoke tests pass (CI)
- [x] Manual testing completed:
  - Build without token → `grep -r cloudflareinsights dist` returns zero matches.
  - Build with `PUBLIC_CF_ANALYTICS_TOKEN=...` → beacon appears exactly once on homepage, `/en`, `/es`, `/en/races`, race edition page, share page, `/en/privacy`, `/404`.
  - Token renders as valid JSON in `data-cf-beacon` attribute.

## Docs Impact

docs updated — `/privacy` i18n copy (en + es) extended with the cookieless-analytics note. No changes needed under `docs/` (per the Doc Update Rule, this is non-material clarification of an already-disclosed third-party).

Closes #122