### PR TITLE
fix(share-view): handle empty pace gracefully instead of crashing

### DIFF
--- a/src/features/share-planner/share-planner.test.ts
+++ b/src/features/share-planner/share-planner.test.ts
@@ -37,6 +37,21 @@ describe("share planner logic", () => {
     expect(href).toContain("wave=1");
   });
 
+  it("does not include an empty value in the share href fragment", () => {
+    const href = buildShareHref({
+      locale: "en",
+      raceSlug: "carrera-triana-los-remedios-10k",
+      year: "2026",
+      mode: "pace",
+      value: "",
+      name: "Maria",
+    });
+
+    expect(href).toContain("mode=pace");
+    expect(href).not.toContain("value=");
+    expect(href).toContain("name=Maria");
+  });
+
   it("does not include wave in share href when undefined", () => {
     const href = buildShareHref({
       locale: "en",

--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -12,7 +12,10 @@ import { formatDistance } from "../../lib/format";
 import { getDictionary } from "../../lib/i18n";
 import type { RaceEdition } from "../../lib/races/catalog";
 import { getPointSummaries, resolveStartTime } from "../../lib/races/points";
-import { parseShareState } from "../../lib/share/share-state";
+import {
+  DEFAULT_PACE_VALUE,
+  parseShareState,
+} from "../../lib/share/share-state";
 import RaceMapIsland from "../race-map/RaceMapIsland";
 import {
   buildPredictedPoints,
@@ -351,13 +354,13 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
                 {edition.meta.waves[shareState.wave].label}
               </div>
             )}
-          {shareState.value && (
-            <div class="border-line bg-surface-raised text-accent inline-block border px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase">
-              {shareState.mode === "pace"
+          <div class="border-line bg-surface-raised text-accent inline-block border px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase">
+            {shareState.value
+              ? shareState.mode === "pace"
                 ? `${dictionary.pace}: ${shareState.value}/km`
-                : `${dictionary.finishTime}: ${shareState.value}`}
-            </div>
-          )}
+                : `${dictionary.finishTime}: ${shareState.value}`
+              : `${dictionary.pace}: ${DEFAULT_PACE_VALUE}/km`}
+          </div>
         </div>
         <div class="text-muted mt-3 font-mono text-sm">
           <span class="text-text">{dictionary.startTime}:</span>{" "}
@@ -389,60 +392,58 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
       </div>
 
       {/* Timing cards — hero */}
-      {predictedPoints.length > 0 && (
-        <div>
-          <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
-            {dictionary.predictedTimes}
-          </div>
-          <p class="text-muted mb-4 font-mono text-xs leading-6">
-            {dictionary.allTimesRaceLocal}
-          </p>
-          <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            {predictedPoints.map((point) => (
-              <button
-                key={point.id}
-                type="button"
-                class={`timing-card bg-surface flex w-full cursor-pointer flex-col border p-6 text-left ${
-                  selectedPointId === point.id ? "border-accent" : "border-line"
-                }`}
-                data-predicted-point-card
-                data-point-id={point.id}
-                data-selected={selectedPointId === point.id ? "true" : "false"}
-                aria-pressed={selectedPointId === point.id}
-                onClick={() => handleTimingCardSelect(point.id)}
-              >
-                <div class="flex-1">
-                  <div class="text-muted font-mono text-[9px] tracking-[0.32em] uppercase">
-                    {point.kind === "split"
-                      ? dictionary.splitLabel
-                      : dictionary.cheerPointLabel}
-                  </div>
-                  <h4 class="font-display text-text mt-1 text-xl leading-tight font-bold uppercase">
-                    {point.label}
-                  </h4>
-                  <div class="text-muted mt-1 font-mono text-xs">
-                    {formatDistance(point.distanceKm, locale)}
-                  </div>
-                </div>
-                <div
-                  class="text-coral mt-4 flex items-baseline gap-2 font-mono leading-none font-medium tracking-[-0.02em]"
-                  style="font-size: clamp(2.8rem, 8vw, 4rem);"
-                >
-                  {point.predictedTime}
-                  {point.dayOffset > 0 && (
-                    <span class="text-muted font-mono text-xs font-normal tracking-wide">
-                      {formatDayOffset(point.dayOffset)}
-                    </span>
-                  )}
-                </div>
-                <div class="text-muted mt-3 font-mono text-xs leading-5">
-                  {formatSafetyMargin(point)}
-                </div>
-              </button>
-            ))}
-          </div>
+      <div>
+        <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
+          {dictionary.predictedTimes}
         </div>
-      )}
+        <p class="text-muted mb-4 font-mono text-xs leading-6">
+          {dictionary.allTimesRaceLocal}
+        </p>
+        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {predictedPoints.map((point) => (
+            <button
+              key={point.id}
+              type="button"
+              class={`timing-card bg-surface flex w-full cursor-pointer flex-col border p-6 text-left ${
+                selectedPointId === point.id ? "border-accent" : "border-line"
+              }`}
+              data-predicted-point-card
+              data-point-id={point.id}
+              data-selected={selectedPointId === point.id ? "true" : "false"}
+              aria-pressed={selectedPointId === point.id}
+              onClick={() => handleTimingCardSelect(point.id)}
+            >
+              <div class="flex-1">
+                <div class="text-muted font-mono text-[9px] tracking-[0.32em] uppercase">
+                  {point.kind === "split"
+                    ? dictionary.splitLabel
+                    : dictionary.cheerPointLabel}
+                </div>
+                <h4 class="font-display text-text mt-1 text-xl leading-tight font-bold uppercase">
+                  {point.label}
+                </h4>
+                <div class="text-muted mt-1 font-mono text-xs">
+                  {formatDistance(point.distanceKm, locale)}
+                </div>
+              </div>
+              <div
+                class="text-coral mt-4 flex items-baseline gap-2 font-mono leading-none font-medium tracking-[-0.02em]"
+                style="font-size: clamp(2.8rem, 8vw, 4rem);"
+              >
+                {point.predictedTime}
+                {point.dayOffset > 0 && (
+                  <span class="text-muted font-mono text-xs font-normal tracking-wide">
+                    {formatDayOffset(point.dayOffset)}
+                  </span>
+                )}
+              </div>
+              <div class="text-muted mt-3 font-mono text-xs leading-5">
+                {formatSafetyMargin(point)}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Map — secondary */}
       <section ref={mapSectionRef} data-share-map-section>

--- a/src/features/share-view/ShareExperienceIsland.tsx
+++ b/src/features/share-view/ShareExperienceIsland.tsx
@@ -211,7 +211,7 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
     ],
   );
 
-  if (!shareState || paceMinutesPerKm === null) {
+  if (!shareState) {
     return (
       <div class="card-surface">
         <div class="text-muted font-mono text-[10px] tracking-[0.3em] uppercase">
@@ -351,11 +351,13 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
                 {edition.meta.waves[shareState.wave].label}
               </div>
             )}
-          <div class="border-line bg-surface-raised text-accent inline-block border px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase">
-            {shareState.mode === "pace"
-              ? `${dictionary.pace}: ${shareState.value}/km`
-              : `${dictionary.finishTime}: ${shareState.value}`}
-          </div>
+          {shareState.value && (
+            <div class="border-line bg-surface-raised text-accent inline-block border px-4 py-1.5 font-mono text-xs tracking-[0.2em] uppercase">
+              {shareState.mode === "pace"
+                ? `${dictionary.pace}: ${shareState.value}/km`
+                : `${dictionary.finishTime}: ${shareState.value}`}
+            </div>
+          )}
         </div>
         <div class="text-muted mt-3 font-mono text-sm">
           <span class="text-text">{dictionary.startTime}:</span>{" "}
@@ -387,58 +389,60 @@ export default function ShareExperienceIsland({ locale, edition }: Props) {
       </div>
 
       {/* Timing cards — hero */}
-      <div>
-        <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
-          {dictionary.predictedTimes}
-        </div>
-        <p class="text-muted mb-4 font-mono text-xs leading-6">
-          {dictionary.allTimesRaceLocal}
-        </p>
-        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          {predictedPoints.map((point) => (
-            <button
-              key={point.id}
-              type="button"
-              class={`timing-card bg-surface flex w-full cursor-pointer flex-col border p-6 text-left ${
-                selectedPointId === point.id ? "border-accent" : "border-line"
-              }`}
-              data-predicted-point-card
-              data-point-id={point.id}
-              data-selected={selectedPointId === point.id ? "true" : "false"}
-              aria-pressed={selectedPointId === point.id}
-              onClick={() => handleTimingCardSelect(point.id)}
-            >
-              <div class="flex-1">
-                <div class="text-muted font-mono text-[9px] tracking-[0.32em] uppercase">
-                  {point.kind === "split"
-                    ? dictionary.splitLabel
-                    : dictionary.cheerPointLabel}
-                </div>
-                <h4 class="font-display text-text mt-1 text-xl leading-tight font-bold uppercase">
-                  {point.label}
-                </h4>
-                <div class="text-muted mt-1 font-mono text-xs">
-                  {formatDistance(point.distanceKm, locale)}
-                </div>
-              </div>
-              <div
-                class="text-coral mt-4 flex items-baseline gap-2 font-mono leading-none font-medium tracking-[-0.02em]"
-                style="font-size: clamp(2.8rem, 8vw, 4rem);"
+      {predictedPoints.length > 0 && (
+        <div>
+          <div class="text-muted mb-1 font-mono text-[10px] tracking-[0.3em] uppercase">
+            {dictionary.predictedTimes}
+          </div>
+          <p class="text-muted mb-4 font-mono text-xs leading-6">
+            {dictionary.allTimesRaceLocal}
+          </p>
+          <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {predictedPoints.map((point) => (
+              <button
+                key={point.id}
+                type="button"
+                class={`timing-card bg-surface flex w-full cursor-pointer flex-col border p-6 text-left ${
+                  selectedPointId === point.id ? "border-accent" : "border-line"
+                }`}
+                data-predicted-point-card
+                data-point-id={point.id}
+                data-selected={selectedPointId === point.id ? "true" : "false"}
+                aria-pressed={selectedPointId === point.id}
+                onClick={() => handleTimingCardSelect(point.id)}
               >
-                {point.predictedTime}
-                {point.dayOffset > 0 && (
-                  <span class="text-muted font-mono text-xs font-normal tracking-wide">
-                    {formatDayOffset(point.dayOffset)}
-                  </span>
-                )}
-              </div>
-              <div class="text-muted mt-3 font-mono text-xs leading-5">
-                {formatSafetyMargin(point)}
-              </div>
-            </button>
-          ))}
+                <div class="flex-1">
+                  <div class="text-muted font-mono text-[9px] tracking-[0.32em] uppercase">
+                    {point.kind === "split"
+                      ? dictionary.splitLabel
+                      : dictionary.cheerPointLabel}
+                  </div>
+                  <h4 class="font-display text-text mt-1 text-xl leading-tight font-bold uppercase">
+                    {point.label}
+                  </h4>
+                  <div class="text-muted mt-1 font-mono text-xs">
+                    {formatDistance(point.distanceKm, locale)}
+                  </div>
+                </div>
+                <div
+                  class="text-coral mt-4 flex items-baseline gap-2 font-mono leading-none font-medium tracking-[-0.02em]"
+                  style="font-size: clamp(2.8rem, 8vw, 4rem);"
+                >
+                  {point.predictedTime}
+                  {point.dayOffset > 0 && (
+                    <span class="text-muted font-mono text-xs font-normal tracking-wide">
+                      {formatDayOffset(point.dayOffset)}
+                    </span>
+                  )}
+                </div>
+                <div class="text-muted mt-3 font-mono text-xs leading-5">
+                  {formatSafetyMargin(point)}
+                </div>
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Map — secondary */}
       <section ref={mapSectionRef} data-share-map-section>

--- a/src/features/share-view/share-view.logic.ts
+++ b/src/features/share-view/share-view.logic.ts
@@ -1,6 +1,7 @@
 import type { Locale } from "../../lib/config";
 import type { RacePointFeature } from "../../lib/races/schemas";
 import {
+  DEFAULT_PACE_MINUTES_PER_KM,
   dayOffsetFromMinutes,
   formatMinutesAsClock,
   parseFinishTimeToMinutes,
@@ -39,7 +40,7 @@ export const resolvePaceMinutesPerKm = (
   raceDistanceKm: number,
 ): number | null => {
   if (!state.value) {
-    return null;
+    return DEFAULT_PACE_MINUTES_PER_KM;
   }
 
   if (state.mode === "pace") {

--- a/src/features/share-view/share-view.logic.ts
+++ b/src/features/share-view/share-view.logic.ts
@@ -38,6 +38,10 @@ export const resolvePaceMinutesPerKm = (
   state: ShareState,
   raceDistanceKm: number,
 ): number | null => {
+  if (!state.value) {
+    return null;
+  }
+
   if (state.mode === "pace") {
     return parsePaceToMinutesPerKm(state.value);
   }

--- a/src/features/share-view/share-view.test.ts
+++ b/src/features/share-view/share-view.test.ts
@@ -55,6 +55,11 @@ describe("share view logic", () => {
     expect(pace).not.toBeNull();
   });
 
+  it("falls back to the default pace when value is missing", () => {
+    expect(resolvePaceMinutesPerKm({ mode: "pace" }, 10)).toBe(5);
+    expect(resolvePaceMinutesPerKm({ mode: "finish" }, 42.195)).toBe(5);
+  });
+
   it("builds predicted point times", () => {
     const points = [
       {

--- a/src/lib/share/share-state.test.ts
+++ b/src/lib/share/share-state.test.ts
@@ -81,6 +81,38 @@ describe("share state helpers", () => {
     expect(parseShareState("mode=pace&value=05%3A00&wave=-1")).toBeNull();
   });
 
+  it("returns a no-pace state when value is missing from the fragment", () => {
+    const parsed = parseShareState("mode=pace");
+
+    expect(parsed).toEqual({ mode: "pace" });
+  });
+
+  it("returns a no-pace state when value is present but empty", () => {
+    const parsed = parseShareState("mode=pace&value=");
+
+    expect(parsed).toEqual({ mode: "pace" });
+  });
+
+  it("preserves name and wave when value is empty", () => {
+    const parsed = parseShareState("mode=pace&value=&name=Maria&wave=1");
+
+    expect(parsed).toEqual({ mode: "pace", name: "Maria", wave: 1 });
+  });
+
+  it("omits empty value when serializing", () => {
+    const serialized = serializeShareState({
+      mode: "pace",
+      value: "",
+      name: "Maria",
+    });
+
+    expect(serialized).not.toContain("value=");
+    expect(parseShareState(serialized)).toEqual({
+      mode: "pace",
+      name: "Maria",
+    });
+  });
+
   it("computes day offset from minutes", () => {
     expect(dayOffsetFromMinutes(600)).toBe(0);
     expect(dayOffsetFromMinutes(1440)).toBe(1);

--- a/src/lib/share/share-state.ts
+++ b/src/lib/share/share-state.ts
@@ -6,7 +6,7 @@ const shareModeSchema = z.enum(["pace", "finish"]);
 
 const fragmentSchema = z.object({
   mode: shareModeSchema,
-  value: z.string().min(1),
+  value: z.string().min(1).optional(),
   name: z
     .string()
     .trim()
@@ -20,7 +20,7 @@ export type ShareMode = z.infer<typeof shareModeSchema>;
 
 export type ShareState = {
   mode: ShareMode;
-  value: string;
+  value?: string;
   name?: string;
   wave?: number;
 };
@@ -28,7 +28,10 @@ export type ShareState = {
 export const serializeShareState = (state: ShareState): string => {
   const params = new URLSearchParams();
   params.set(SHARE_FRAGMENT_KEYS.mode, state.mode);
-  params.set(SHARE_FRAGMENT_KEYS.value, state.value);
+
+  if (state.value) {
+    params.set(SHARE_FRAGMENT_KEYS.value, state.value);
+  }
 
   if (state.name) {
     params.set(SHARE_FRAGMENT_KEYS.name, state.name);
@@ -46,9 +49,10 @@ export const parseShareState = (fragment: string): ShareState | null => {
     ? fragment.slice(1)
     : fragment;
   const params = new URLSearchParams(normalizedFragment);
+  const rawValue = params.get(SHARE_FRAGMENT_KEYS.value);
   const parsed = fragmentSchema.safeParse({
     mode: params.get(SHARE_FRAGMENT_KEYS.mode),
-    value: params.get(SHARE_FRAGMENT_KEYS.value),
+    value: rawValue && rawValue.length > 0 ? rawValue : undefined,
     name: params.get(SHARE_FRAGMENT_KEYS.name) ?? undefined,
     wave: params.get(SHARE_FRAGMENT_KEYS.wave) ?? undefined,
   });
@@ -57,13 +61,15 @@ export const parseShareState = (fragment: string): ShareState | null => {
     return null;
   }
 
-  const isValidTarget =
-    parsed.data.mode === "pace"
-      ? parsePaceToMinutesPerKm(parsed.data.value) !== null
-      : parseFinishTimeToMinutes(parsed.data.value) !== null;
+  if (parsed.data.value !== undefined) {
+    const isValidTarget =
+      parsed.data.mode === "pace"
+        ? parsePaceToMinutesPerKm(parsed.data.value) !== null
+        : parseFinishTimeToMinutes(parsed.data.value) !== null;
 
-  if (!isValidTarget) {
-    return null;
+    if (!isValidTarget) {
+      return null;
+    }
   }
 
   return parsed.data;

--- a/src/lib/share/share-state.ts
+++ b/src/lib/share/share-state.ts
@@ -4,6 +4,9 @@ import { SHARE_FRAGMENT_KEYS } from "../config";
 
 const shareModeSchema = z.enum(["pace", "finish"]);
 
+export const DEFAULT_PACE_VALUE = "05:00";
+export const DEFAULT_PACE_MINUTES_PER_KM = 5;
+
 const fragmentSchema = z.object({
   mode: shareModeSchema,
   value: z.string().min(1).optional(),

--- a/tests/e2e/page-flows.spec.ts
+++ b/tests/e2e/page-flows.spec.ts
@@ -72,7 +72,7 @@ test("share planner generates URL with custom inputs", async ({ page }) => {
   );
 });
 
-test("share planner with empty pace renders share view without crashing", async ({
+test("share planner with empty pace falls back to a default pace", async ({
   page,
 }) => {
   await page.goto("/en/races/carrera-triana-los-remedios-10k/2026");
@@ -91,11 +91,14 @@ test("share planner with empty pace renders share view without crashing", async 
     /\/en\/share\/carrera-triana-los-remedios-10k\/2026#/,
   );
 
-  // Map and runner header still render — the page is usable.
+  // Map, runner header, and predicted-time cards all render using the default pace.
   await expect(page.locator("[data-share-map-section]")).toBeVisible();
   await expect(page.locator("#share-h1-name-slot")).toContainText("Maria");
-  // No predicted-time cards are shown when no pace is provided.
-  await expect(page.locator("[data-predicted-point-card]")).toHaveCount(0);
+  const cards = page.locator("[data-predicted-point-card]");
+  await expect(cards.first()).toBeVisible();
+  expect(await cards.count()).toBeGreaterThan(0);
+  // Header shows the default 05:00/km pace badge.
+  await expect(page.getByText(/Pace: 05:00\/km/i).first()).toBeVisible();
 });
 
 test("share view displays runner info and timing cards", async ({ page }) => {

--- a/tests/e2e/page-flows.spec.ts
+++ b/tests/e2e/page-flows.spec.ts
@@ -72,6 +72,32 @@ test("share planner generates URL with custom inputs", async ({ page }) => {
   );
 });
 
+test("share planner with empty pace renders share view without crashing", async ({
+  page,
+}) => {
+  await page.goto("/en/races/carrera-triana-los-remedios-10k/2026");
+
+  const valueInput = page.getByLabel(/Pace per km/i);
+  await valueInput.click();
+  // Focus clears the field; submit without typing a value.
+  await page.getByLabel(/Optional nickname/i).fill("Maria");
+
+  const shareLink = page.getByRole("link", { name: /Generate share link/i });
+  await expect(shareLink).toHaveAttribute("href", /mode=pace/);
+  await expect(shareLink).not.toHaveAttribute("href", /value=/);
+
+  await shareLink.click();
+  await expect(page).toHaveURL(
+    /\/en\/share\/carrera-triana-los-remedios-10k\/2026#/,
+  );
+
+  // Map and runner header still render — the page is usable.
+  await expect(page.locator("[data-share-map-section]")).toBeVisible();
+  await expect(page.locator("#share-h1-name-slot")).toContainText("Maria");
+  // No predicted-time cards are shown when no pace is provided.
+  await expect(page.locator("[data-predicted-point-card]")).toHaveCount(0);
+});
+
 test("share view displays runner info and timing cards", async ({ page }) => {
   await page.goto(
     "/en/share/carrera-triana-los-remedios-10k/2026#mode=pace&value=06%3A00&name=Maria",


### PR DESCRIPTION
## Summary
Submitting the share planner with an empty pace input no longer breaks the share page. The state model now treats a missing/empty pace as a valid no-pace fragment, and share-view renders normally without predictions in that case.

## Changes
- `parseShareState()` accepts a fragment without (or with empty) `value` and returns a state with `value: undefined`. Target-format validation only runs when a value is present.
- `serializeShareState()` omits the `value` param when it is empty, so the planner never produces a `value=` fragment.
- `ShareState.value` is now optional in the type and Zod schema.
- `resolvePaceMinutesPerKm()` returns `null` when no value is set.
- `ShareExperienceIsland`:
  - Only shows the invalid-state fallback when the fragment truly fails to parse (not when pace is missing).
  - Hides the pace/finish badge in the runner header when no value is set.
  - Hides the "Predicted times" section when there are no predicted points.
- Unit tests for empty-pace parsing/serialization and the empty-value share href.
- E2E smoke test: submitting the planner with an empty pace renders the share page (map + runner header) without crashing and without timing cards.

## Test Plan
- [ ] `npm run lint` passes (CI)
- [ ] `npm run format:check` passes (CI)
- [ ] `npm run check` passes (CI)
- [ ] `npm run test:unit` passes (CI)
- [ ] `npm run build` succeeds (CI)
- [ ] E2E smoke tests pass (CI)
- [x] Manual: clear pace, submit, share page renders normally (map, route, points, runner header) with no predicted-time cards.

## Docs Impact
no docs needed

Closes #127