### PR TITLE
fix(share-view): bundle leaflet CSS so share-page map renders

### DIFF
--- a/src/pages/[locale]/share/[race]/[year].astro
+++ b/src/pages/[locale]/share/[race]/[year].astro
@@ -1,4 +1,10 @@
 ---
+// Leaflet CSS is imported here (not just inside RaceMapIsland) because
+// ShareExperienceIsland is hydrated with `client:only`, and Astro's CSS
+// analyzer does not follow transitive imports through `client:only` islands.
+// Without this, leaflet panes fall back to position:static and tiles render broken.
+import "leaflet/dist/leaflet.css";
+
 import BaseLayout from "../../../../layouts/BaseLayout.astro";
 import ShareExperienceIsland from "../../../../features/share-view/ShareExperienceIsland";
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -161,6 +161,25 @@ test("share page stays noindex", async ({ page }) => {
   expect(twitterImage).toBe(openGraphImage);
 });
 
+test("share page loads leaflet CSS so map tiles render correctly", async ({
+  page,
+}) => {
+  await page.goto(
+    "/en/share/carrera-triana-los-remedios-10k/2026#mode=pace&value=05%3A00&name=Pepe",
+  );
+
+  const tilePane = page.locator(
+    '[data-map-mode="spectator"] .leaflet-tile-pane',
+  );
+
+  await expect(tilePane).toBeVisible();
+  await expect
+    .poll(() =>
+      tilePane.evaluate((element) => window.getComputedStyle(element).position),
+    )
+    .toBe("absolute");
+});
+
 test("race page emits open graph and twitter metadata", async ({ page }) => {
   await page.goto("/en/races/carrera-triana-los-remedios-10k/2026");
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -172,7 +172,7 @@ test("share page loads leaflet CSS so map tiles render correctly", async ({
     '[data-map-mode="spectator"] .leaflet-tile-pane',
   );
 
-  await expect(tilePane).toBeVisible();
+  await tilePane.waitFor({ state: "attached" });
   await expect
     .poll(() =>
       tilePane.evaluate((element) => window.getComputedStyle(element).position),


### PR DESCRIPTION
## Summary
The share page (`/<locale>/share/<race>/<year>`) was rendering the Leaflet map with only a single visible tile in the middle and a blank background elsewhere — the route line and points were also missing. Root cause: Leaflet's stylesheet was never bundled onto the share page.

## Changes
- `src/pages/[locale]/share/[race]/[year].astro`: import `leaflet/dist/leaflet.css` directly in the page frontmatter so Astro bundles it. `ShareExperienceIsland` is hydrated with `client:only="preact"`, and Astro's CSS analyzer does not follow transitive CSS imports through `client:only` islands — so the existing import inside `RaceMapIsland.tsx` was being dropped from the share-page bundle. Without those rules, `.leaflet-tile-pane`, `.leaflet-layer`, and `.leaflet-tile-container` fell back to `position: static`, which caused tiles (translated via per-tile `transform`) to flow vertically off-screen as normal block elements.
- `tests/e2e/app.spec.ts`: add a Playwright regression asserting `.leaflet-tile-pane` is `position: absolute` after mount on the share page. This catches the missing-CSS class of regression directly.

The canonical race detail page (`/<locale>/races/<race>/<year>`) was unaffected because it uses `<RaceMapIsland client:visible />`, which gives Astro an SSR pass that discovers the CSS import normally.

## Test Plan
- [ ] `npm run lint` passes (CI)
- [ ] `npm run format:check` passes (CI)
- [ ] `npm run check` passes (CI)
- [ ] `npm run test:unit` passes (CI)
- [ ] `npm run build` succeeds (CI)
- [ ] E2E smoke tests pass (CI), including the new tile-pane regression
- [x] Manual testing: production build (`npm run build && npm run preview`) verified inline and fullscreen map render correctly across desktop and mobile viewports

## Docs Impact
no docs needed

Closes #126